### PR TITLE
Fix Makefile for new binutils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -fvar-tracking -fvar
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 ASFLAGS = -m32 -gdwarf-2 -Wa,-divide
 # FreeBSD ld wants ``elf_i386_fbsd''
-LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null)
+LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null | head -n 1)
 
 xv6.img: bootblock kernel fs.img
 	dd if=/dev/zero of=xv6.img count=10000
@@ -121,6 +121,7 @@ entryother: entryother.S
 
 initcode: initcode.S
 	$(CC) $(CFLAGS) -nostdinc -I. -c initcode.S
+	objcopy --remove-section .note.gnu.property initcode.o
 	$(LD) $(LDFLAGS) -N -e start -Ttext 0 -o initcode.out initcode.o
 	$(OBJCOPY) -S -O binary initcode.out initcode
 	$(OBJDUMP) -S initcode.o > initcode.asm
@@ -151,6 +152,7 @@ vectors.S: vectors.pl
 ULIB = ulib.o usys.o printf.o umalloc.o
 
 _%: %.o $(ULIB)
+	objcopy --remove-section .note.gnu.property ulib.o
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
 	$(OBJDUMP) -S $@ > $*.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $*.sym


### PR DESCRIPTION
As seen on this campuswire [post](https://campuswire.com/c/G044CEFAB/feed/254), xv6 no longer worked when I updated my binutils. I am running ubuntu 20.04 LTS. The line in the makefile was invoking an LD command with a syntax error. This pull request extrapolates fixes I found in newer versions of xv6. Additionally I added two lines which fix an infinite bootloop problem also caused by the binutils update. I was able to run the tests for the exam with the modified makefile but I have not tried running it from the anubis IDE yet. However, I am pretty sure the fix will not have any negative effect on current users unaffected by the bug