### PR TITLE
Fix bootloop on binutils >= 2.36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ os3224.image:
 # TOOLPREFIX = i386-jos-elf
 
 # Using native tools (e.g., on X86 Linux)
-#TOOLPREFIX = 
+#TOOLPREFIX =
 
 # Try to infer the correct TOOLPREFIX if not set
 ifndef TOOLPREFIX
@@ -121,6 +121,7 @@ entryother: entryother.S
 
 initcode: initcode.S
 	$(CC) $(CFLAGS) -nostdinc -I. -c initcode.S
+	objcopy --remove-section .note.gnu.property initcode.o
 	$(LD) $(LDFLAGS) -N -e start -Ttext 0 -o initcode.out initcode.o
 	$(OBJCOPY) -S -O binary initcode.out initcode
 	$(OBJDUMP) -S initcode.o > initcode.asm
@@ -151,6 +152,7 @@ vectors.S: vectors.pl
 ULIB = ulib.o usys.o printf.o umalloc.o
 
 _%: %.o $(ULIB)
+	objcopy --remove-section .note.gnu.property ulib.o
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
 	$(OBJDUMP) -S $@ > $*.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $*.sym
@@ -192,7 +194,7 @@ fs.img: mkfs README.md $(UPROGS)
 
 -include *.d
 
-clean: 
+clean:
 	rm -f *.tex *.dvi *.idx *.aux *.log *.ind *.ilg \
 	*.o *.d *.asm *.sym vectors.S bootblock entryother \
 	initcode initcode.out kernel xv6.img fs.img kernelmemfs mkfs \

--- a/usertests.c
+++ b/usertests.c
@@ -1399,7 +1399,9 @@ void sbrktest(void) {
     exit();
   }
   lastaddr = (char *)(BIG - 1);
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
   *lastaddr = 99;
+#pragma GCC diagnostic pop
 
   // can one de-allocate?
   a = sbrk(0);


### PR DESCRIPTION
Linux SysV ABI extension added the `.note.gnu.property` section to describe special handling requirements to the linker and runtime loader. Modern toolchains include this section in our final binary, predictably causing QEMU to bootloop.

This removes the section and another warning (which breaks compilation due to -Werror), so students can build and run xv6 on their local machines. All credit to [Lorenzo's original PR](https://github.com/mit-pdos/xv6-public/pull/155).