### PR TITLE
Small makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,41 +88,40 @@ AS = $(TOOLPREFIX)gas
 LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
-#CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb -m32 -Werror -fno-omit-frame-pointer
-CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -fvar-tracking -fvar-tracking-assignments -O0 -g -Wall -MD -gdwarf-2 -m32 -Werror -fno-omit-frame-pointer
+OBJFLAGS = -S -O binary -j .text
+CFLAGS = -nostdinc -fno-pic -static -fno-builtin -fno-strict-aliasing -fvar-tracking -fvar-tracking-assignments -O0 -g -Wall -MD -gdwarf-2 -m32 -Werror -fno-omit-frame-pointer
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 ASFLAGS = -m32 -gdwarf-2 -Wa,-divide
 # FreeBSD ld wants ``elf_i386_fbsd''
 LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null | head -n 1)
 
 xv6.img: bootblock kernel fs.img
-	dd if=/dev/zero of=xv6.img count=10000
-	dd if=bootblock of=xv6.img conv=notrunc
-	dd if=kernel of=xv6.img seek=1 conv=notrunc
+	dd if=bootblock of=xv6.img
+	dd if=kernel of=xv6.img seek=1
 
 xv6memfs.img: bootblock kernelmemfs
-	dd if=/dev/zero of=xv6memfs.img count=10000
-	dd if=bootblock of=xv6memfs.img conv=notrunc
-	dd if=kernelmemfs of=xv6memfs.img seek=1 conv=notrunc
+	dd if=bootblock of=xv6memfs.img
+	dd if=kernelmemfs of=xv6memfs.img seek=1
 
 bootblock: bootasm.S bootmain.c
-	$(CC) $(CFLAGS) -fno-pic -O -nostdinc -I. -c bootmain.c
-	$(CC) $(CFLAGS) -fno-pic -nostdinc -I. -c bootasm.S
+	# bootmain must be optimized or it won't fit in the bootloader section
+	$(CC) $(CFLAGS) -O -c bootmain.c
+	$(CC) $(CFLAGS) -c bootasm.S
 	$(LD) $(LDFLAGS) -N -e start -Ttext 0x7C00 -o bootblock.o bootasm.o bootmain.o
 	$(OBJDUMP) -S bootblock.o > bootblock.asm
-	$(OBJCOPY) -S -O binary -j .text bootblock.o bootblock
+	$(OBJCOPY) $(OBJFLAGS) bootblock.o bootblock
 	./sign.pl bootblock
 
 entryother: entryother.S
-	$(CC) $(CFLAGS) -fno-pic -nostdinc -I. -c entryother.S
+	$(CC) $(CFLAGS) -c entryother.S
 	$(LD) $(LDFLAGS) -N -e start -Ttext 0x7000 -o bootblockother.o entryother.o
-	$(OBJCOPY) -S -O binary -j .text bootblockother.o entryother
+	$(OBJCOPY) $(OBJFLAGS) bootblockother.o entryother
 	$(OBJDUMP) -S bootblockother.o > entryother.asm
 
 initcode: initcode.S
-	$(CC) $(CFLAGS) -nostdinc -I. -c initcode.S
+	$(CC) $(CFLAGS) -c initcode.S
 	$(LD) $(LDFLAGS) -N -e start -Ttext 0 -o initcode.out initcode.o
-	$(OBJCOPY) --remove-section .note.gnu.property -S -O binary initcode.out initcode
+	$(OBJCOPY) $(OBJFLAGS) initcode.out initcode
 	$(OBJDUMP) -S initcode.o > initcode.asm
 
 kernel: $(OBJS) entry.o entryother initcode kernel.ld


### PR DESCRIPTION
Removes confusing flags and commands from the makefile that weren't doing anything, and seem to be copy-pasted from older scripts.

This still isn't the "correct" answer, and I'm unclear why the `.note.gnu.property` section being present in ulib.o causes `init` to crash so that line of the makefile is still a mystery; but this should be reasonably future-proof against other binutils changes.

The right answer is to write linker scripts for targets that need them, instead of using dd and objcopy as a bootleg linker script. This would largely just be a final bootable image .ld file that assembles the sections from the relevant objects. Also getting away from the fragility of a handcoded makefile and switching to cmake targets or similar (which would allow us to switch between debug/release builds for free without changing lines in a build file).

But that's hard and this is trivial, so this is the patch we get instead.