### PR TITLE
Fix builds on GCC 11 and 12, add realloc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 OBJFLAGS = -S -O binary -j .text
 CFLAGS = -nostdinc -fno-pic -static -fno-builtin -fno-strict-aliasing -fvar-tracking -fvar-tracking-assignments -O0 -g -Wall -MD -gdwarf-2 -m32 -Werror -fno-omit-frame-pointer -ggdb
-CFLAGS += -I.
+CFLAGS += -I. -mno-sse
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 ASFLAGS = -m32 -gdwarf-2 -Wa,-divide -I.
 # FreeBSD ld wants ``elf_i386_fbsd''
@@ -111,8 +111,7 @@ $K/kernel: $(OBJS) $U/initcode $K/entryother
 ULIB = $U/ulib.o $U/usys.o $U/printf.o $U/umalloc.o
 
 _%: %.o $(ULIB)
-	$(OBJCOPY) --remove-section .note.gnu.property $U/ulib.o
-	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(LD) $(LDFLAGS) -T $U/user.ld -o $@ $^
 	$(OBJDUMP) -S $@ > $*.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $*.sym
 
@@ -178,9 +177,9 @@ CPUS := 1
 endif
 
 QEMUOPTS = \
-   -drive file=xv6.img,media=disk,index=0,format=raw \
-   -drive file=fs.img,index=1,media=disk,format=raw \
-   -smp $(CPUS) -m 512 $(QEMUEXTRA) -display none -nographic
+	-drive file=xv6.img,media=disk,index=0,format=raw \
+	-drive file=fs.img,index=1,media=disk,format=raw \
+	-smp $(CPUS) -m 512 -display none -nographic
 
 qemu: $K/kernel fs.img xv6.img
 	$(QEMU) $(QEMUOPTS)

--- a/user/sh.c
+++ b/user/sh.c
@@ -54,6 +54,10 @@ void panic(char *);
 struct cmd *parsecmd(char *);
 
 // Execute cmd.  Never returns.
+#if __GNUC__ >= 12
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winfinite-recursion"
+#endif
 void runcmd(struct cmd *cmd) {
   int p[2];
   struct backcmd *bcmd;
@@ -127,6 +131,9 @@ void runcmd(struct cmd *cmd) {
   }
   exit();
 }
+#if __GNUC__ >= 12
+#pragma GCC diagnostic pop
+#endif
 
 int getcmd(char *buf, int nbuf) {
   printf(2, "$ ");

--- a/user/umalloc.c
+++ b/user/umalloc.c
@@ -56,6 +56,22 @@ static Header *morecore(uint nu) {
   return freep;
 }
 
+void *realloc(void *ap, uint nbytes) {
+  Header *bp = (Header *)ap - 1;
+  uint nunits = (nbytes + sizeof(Header) - 1) / sizeof(Header) + 1;
+
+  if (bp->s.size >= nunits)
+    return ap;
+
+  void *np = malloc(nbytes);
+  if (!np)
+    return 0;
+
+  memmove(np, ap, (bp->s.size - 1) * sizeof(Header));
+  free(ap);
+  return np;
+}
+
 void *malloc(uint nbytes) {
   Header *p, *prevp;
   uint nunits;

--- a/user/user.h
+++ b/user/user.h
@@ -36,4 +36,5 @@ uint strlen(char*);
 void* memset(void*, int, uint);
 void* malloc(uint);
 void free(void*);
+void* realloc(void*, uint);
 int atoi(const char*);

--- a/user/user.ld
+++ b/user/user.ld
@@ -1,0 +1,33 @@
+OUTPUT_FORMAT("elf32-i386", "elf32-i386", "elf32-i386")
+OUTPUT_ARCH(i386)
+ENTRY(main)
+
+SECTIONS
+{
+	.text : {
+		*(.text .stub .text.*)
+	}
+
+	PROVIDE(etext = .);	/* Define the 'etext' symbol to this value */
+
+	.rodata : {
+		*(.rodata .rodata.*)
+	}
+	/* The data segment */
+	.data : {
+		*(.data)
+	}
+
+	PROVIDE(edata = .);
+
+	.bss : {
+		*(.bss)
+	}
+
+	PROVIDE(end = .);
+
+	/DISCARD/ : {
+		*(.eh_frame)
+    *(.note.gnu.property)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/AnubisLMS/xv6/issues/7

Also adds a long overdue `realloc` function. I don't know if the grad OS class teaches the K&R allocator, but it's 10 line function I'm tired of endlessly going over with students because in the undergrad course we don't talk about userspace allocators at all.

Tested on Anubis and locally, will merge sometime tomorrow morning unless anyone urgently objects.