### PR TITLE
ADD struct ptable, extern the ptable

### DIFF
--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -9,6 +9,7 @@ struct file;
 struct inode;
 struct pipe;
 struct proc;
+struct ptable;
 struct rtcdate;
 struct spinlock;
 struct stat;

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -7,10 +7,7 @@
 #include "kernel/proc.h"
 #include "kernel/spinlock.h"
 
-struct {
-  struct spinlock lock;
-  struct proc proc[NPROC];
-} ptable;
+struct ptable ptable;
 
 static struct proc *initproc;
 
@@ -77,7 +74,8 @@ void userinit(void) {
   initproc = p;
   if ((p->pgdir = setupkvm()) == 0)
     panic("userinit: out of memory?");
-  inituvm(p->pgdir, _binary_user_initcode_start, (int)_binary_user_initcode_size);
+  inituvm(p->pgdir, _binary_user_initcode_start,
+          (int)_binary_user_initcode_size);
   p->sz = PGSIZE;
   memset(p->tf, 0, sizeof(*p->tf));
   p->tf->cs = (SEG_UCODE << 3) | DPL_USER;

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -2,7 +2,9 @@
 #define XV6_PROC_H
 
 #include "types.h"
+#include "param.h"
 #include "defs.h"
+#include "spinlock.h"
 #include "mmu.h"
 
 // Segments in proc->gdt.
@@ -81,6 +83,13 @@ struct proc {
   struct inode *cwd;          // Current directory
   char name[16];              // Process name (debugging)
 };
+
+struct ptable {
+  struct spinlock lock;
+  struct proc proc[NPROC];
+};
+
+extern struct ptable ptable;
 
 // Process memory is laid out contiguously, low addresses first:
 //   text

--- a/kernel/spinlock.h
+++ b/kernel/spinlock.h
@@ -2,7 +2,7 @@
 #define XV6_SPINLOCK_H
 
 #include "types.h"
-#include "proc.h"
+#include "defs.h"
 
 // Mutual exclusion lock.
 struct spinlock {


### PR DESCRIPTION
Student: "Hey nickelpro, why can't I access the `ptable` in any file except _proc.c_?"

nickelpro: "Uh well, it's what's called an anonymous struct so you can't forward declare it in a header file or use extern to make it visible..."

Student: :sleeping:

If I have this exchange one more time I'm going to commit sudoku, all nine numbers. And there's no good reason for this baffling design choice. Let's fix it.