### PR TITLE
CHG: xv6 is not a book

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,29 +1,32 @@
 ---
-Language:        Cpp
-# BasedOnStyle:  LLVM
+Language:      Cpp
+BasedOnStyle:  LLVM
 AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: DontAlign
+AlignArrayOfStructures: None
 AlignConsecutiveMacros: false
 AlignConsecutiveAssignments: false
 AlignConsecutiveBitFields: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Right
-AlignOperands:   Align
+AlignOperands:   DontAlign
 AlignTrailingComments: true
-AllowAllArgumentsOnNextLine: true
-AllowAllConstructorInitializersOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortEnumsOnASingleLine: true
-AllowShortBlocksOnASingleLine: Never
+AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: Empty
 AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: No
+AttributeMacros:
+  - __capability
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
@@ -46,6 +49,7 @@ BraceWrapping:
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
 BreakBeforeBraces: Attach
 BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
@@ -64,39 +68,49 @@ Cpp11BracedListStyle: true
 DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
 IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
     SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
     Priority:        3
     SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '.*'
     Priority:        1
     SortPriority:    0
+    CaseSensitive:   false
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
-IndentCaseLabels: false
+IndentAccessModifiers: false
+IndentCaseLabels: true
 IndentCaseBlocks: false
 IndentGotoLabels: true
 IndentPPDirectives: None
 IndentExternBlock: AfterExternBlock
+IndentRequires:  false
 IndentWidth:     2
 IndentWrappedFunctionNames: false
 InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
+MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
@@ -111,30 +125,43 @@ PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
-PointerAlignment: Right
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
 ReflowComments:  true
-SortIncludes:    false
+ShortNamespaceLines: 1
+SortIncludes:    CaseInsensitive
+SortJavaStaticImport: Before
 SortUsingDeclarations: true
-SpaceAfterCStyleCast: false
+SpaceAfterCStyleCast: true
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeCpp11BracedList: false
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatements
+SpaceBeforeParens: Never
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesInAngles:  Never
 SpacesInConditionalStatement: false
-SpacesInContainerLiterals: true
+SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
 Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
@@ -145,5 +172,6 @@ WhitespaceSensitiveMacros:
   - STRINGIZE
   - PP_STRINGIZE
   - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
 ...
-

--- a/kernel/asm.h
+++ b/kernel/asm.h
@@ -12,7 +12,7 @@
 // The 0xC0 means the limit is in 4096-byte units
 // and (for executable segments) 32-bit mode.
 #define SEG_ASM(type, base, lim)                                               \
-  .word(((lim) >> 12) & 0xffff), ((base)&0xffff);                              \
+  .word(((lim) >> 12) & 0xffff), ((base) &0xffff);                             \
   .byte(((base) >> 16) & 0xff), (0x90 | (type)),                               \
       (0xC0 | (((lim) >> 28) & 0xf)), (((base) >> 24) & 0xff)
 

--- a/kernel/bio.c
+++ b/kernel/bio.c
@@ -20,12 +20,12 @@
 // * B_DIRTY: the buffer data has been modified
 //     and needs to be written to disk.
 
-#include "kernel/types.h"
+#include "buf.h"
 #include "kernel/defs.h"
+#include "kernel/fs.h"
 #include "kernel/param.h"
 #include "kernel/spinlock.h"
-#include "kernel/fs.h"
-#include "buf.h"
+#include "kernel/types.h"
 
 struct {
   struct spinlock lock;
@@ -37,15 +37,14 @@ struct {
 } bcache;
 
 void binit(void) {
-  struct buf *b;
+  struct buf* b;
 
   initlock(&bcache.lock, "bcache");
 
-  // PAGEBREAK!
   // Create linked list of buffers
   bcache.head.prev = &bcache.head;
   bcache.head.next = &bcache.head;
-  for (b = bcache.buf; b < bcache.buf + NBUF; b++) {
+  for(b = bcache.buf; b < bcache.buf + NBUF; b++) {
     b->next = bcache.head.next;
     b->prev = &bcache.head;
     b->dev = -1;
@@ -57,16 +56,16 @@ void binit(void) {
 // Look through buffer cache for block on device dev.
 // If not found, allocate a buffer.
 // In either case, return B_BUSY buffer.
-static struct buf *bget(uint dev, uint blockno) {
-  struct buf *b;
+static struct buf* bget(uint dev, uint blockno) {
+  struct buf* b;
 
   acquire(&bcache.lock);
 
 loop:
   // Is the block already cached?
-  for (b = bcache.head.next; b != &bcache.head; b = b->next) {
-    if (b->dev == dev && b->blockno == blockno) {
-      if (!(b->flags & B_BUSY)) {
+  for(b = bcache.head.next; b != &bcache.head; b = b->next) {
+    if(b->dev == dev && b->blockno == blockno) {
+      if(!(b->flags & B_BUSY)) {
         b->flags |= B_BUSY;
         release(&bcache.lock);
         return b;
@@ -79,8 +78,8 @@ loop:
   // Not cached; recycle some non-busy and clean buffer.
   // "clean" because B_DIRTY and !B_BUSY means log.c
   // hasn't yet committed the changes to the buffer.
-  for (b = bcache.head.prev; b != &bcache.head; b = b->prev) {
-    if ((b->flags & B_BUSY) == 0 && (b->flags & B_DIRTY) == 0) {
+  for(b = bcache.head.prev; b != &bcache.head; b = b->prev) {
+    if((b->flags & B_BUSY) == 0 && (b->flags & B_DIRTY) == 0) {
       b->dev = dev;
       b->blockno = blockno;
       b->flags = B_BUSY;
@@ -92,19 +91,19 @@ loop:
 }
 
 // Return a B_BUSY buf with the contents of the indicated block.
-struct buf *bread(uint dev, uint blockno) {
-  struct buf *b;
+struct buf* bread(uint dev, uint blockno) {
+  struct buf* b;
 
   b = bget(dev, blockno);
-  if (!(b->flags & B_VALID)) {
+  if(!(b->flags & B_VALID)) {
     iderw(b);
   }
   return b;
 }
 
 // Write b's contents to disk.  Must be B_BUSY.
-void bwrite(struct buf *b) {
-  if ((b->flags & B_BUSY) == 0)
+void bwrite(struct buf* b) {
+  if((b->flags & B_BUSY) == 0)
     panic("bwrite");
   b->flags |= B_DIRTY;
   iderw(b);
@@ -112,8 +111,8 @@ void bwrite(struct buf *b) {
 
 // Release a B_BUSY buffer.
 // Move to the head of the MRU list.
-void brelse(struct buf *b) {
-  if ((b->flags & B_BUSY) == 0)
+void brelse(struct buf* b) {
+  if((b->flags & B_BUSY) == 0)
     panic("brelse");
 
   acquire(&bcache.lock);
@@ -130,5 +129,3 @@ void brelse(struct buf *b) {
 
   release(&bcache.lock);
 }
-// PAGEBREAK!
-// Blank page.

--- a/kernel/bootasm.S
+++ b/kernel/bootasm.S
@@ -18,7 +18,7 @@ start:
   movw    %ax,%es             # -> Extra Segment
   movw    %ax,%ss             # -> Stack Segment
 
-  # Physical address line A20 is tied to zero so that the first PCs 
+  # Physical address line A20 is tied to zero so that the first PCs
   # with 2 MB would run software that assumed 1 MB.  Undo that.
 seta20.1:
   inb     $0x64,%al               # Wait for not busy
@@ -44,7 +44,6 @@ seta20.2:
   orl     $CR0_PE, %eax
   movl    %eax, %cr0
 
-//PAGEBREAK!
   # Complete transition to 32-bit protected mode by using long jmp
   # to reload %cs and %eip.  The segment descriptors are set up with no
   # translation, so that the mapping is still the identity mapping.
@@ -85,4 +84,3 @@ gdt:
 gdtdesc:
   .word   (gdtdesc - gdt - 1)             # sizeof(gdt) - 1
   .long   gdt                             # address gdt
-

--- a/kernel/bootmain.c
+++ b/kernel/bootmain.c
@@ -5,37 +5,37 @@
 // bootmain() loads an ELF kernel image from the disk starting at
 // sector 1 and then jumps to the kernel entry routine.
 
-#include "kernel/types.h"
 #include "kernel/elf.h"
-#include "kernel/x86.h"
 #include "kernel/memlayout.h"
+#include "kernel/types.h"
+#include "kernel/x86.h"
 
 #define SECTSIZE 512
 
-void readseg(uchar *, uint, uint);
+void readseg(uchar*, uint, uint);
 
 void bootmain(void) {
-  struct elfhdr *elf;
+  struct elfhdr* elf;
   struct proghdr *ph, *eph;
   void (*entry)(void);
-  uchar *pa;
+  uchar* pa;
 
-  elf = (struct elfhdr *)0x10000; // scratch space
+  elf = (struct elfhdr*) 0x10000; // scratch space
 
   // Read 1st page off disk
-  readseg((uchar *)elf, 4096, 0);
+  readseg((uchar*) elf, 4096, 0);
 
   // Is this an ELF executable?
-  if (elf->magic != ELF_MAGIC)
+  if(elf->magic != ELF_MAGIC)
     return; // let bootasm.S handle error
 
   // Load each program segment (ignores ph flags).
-  ph = (struct proghdr *)((uchar *)elf + elf->phoff);
+  ph = (struct proghdr*) ((uchar*) elf + elf->phoff);
   eph = ph + elf->phnum;
-  for (; ph < eph; ph++) {
-    pa = (uchar *)ph->paddr;
+  for(; ph < eph; ph++) {
+    pa = (uchar*) ph->paddr;
     readseg(pa, ph->filesz, ph->off);
-    if (ph->memsz > ph->filesz)
+    if(ph->memsz > ph->filesz)
       stosb(pa + ph->filesz, 0, ph->memsz - ph->filesz);
   }
 
@@ -47,12 +47,11 @@ void bootmain(void) {
 
 void waitdisk(void) {
   // Wait for disk ready.
-  while ((inb(0x1F7) & 0xC0) != 0x40)
-    ;
+  while((inb(0x1F7) & 0xC0) != 0x40) {}
 }
 
 // Read a single sector at offset into dst.
-void readsect(void *dst, uint offset) {
+void readsect(void* dst, uint offset) {
   // Issue command.
   waitdisk();
   outb(0x1F2, 1); // count = 1
@@ -69,8 +68,8 @@ void readsect(void *dst, uint offset) {
 
 // Read 'count' bytes at 'offset' from kernel into physical address 'pa'.
 // Might copy more than asked.
-void readseg(uchar *pa, uint count, uint offset) {
-  uchar *epa;
+void readseg(uchar* pa, uint count, uint offset) {
+  uchar* epa;
 
   epa = pa + count;
 
@@ -83,6 +82,6 @@ void readseg(uchar *pa, uint count, uint offset) {
   // If this is too slow, we could read lots of sectors at a time.
   // We'd write more to memory than asked, but it doesn't matter --
   // we load in increasing order.
-  for (; pa < epa; pa += SECTSIZE, offset++)
+  for(; pa < epa; pa += SECTSIZE, offset++)
     readsect(pa, offset);
 }

--- a/kernel/buf.h
+++ b/kernel/buf.h
@@ -1,17 +1,19 @@
 #ifndef XV6_BUF_H
 #define XV6_BUF_H
 
+#include "fs.h"
 #include "types.h"
 
 struct buf {
   int flags;
   uint dev;
   uint blockno;
-  struct buf *prev; // LRU cache list
-  struct buf *next;
-  struct buf *qnext; // disk queue
+  struct buf* prev; // LRU cache list
+  struct buf* next;
+  struct buf* qnext; // disk queue
   uchar data[BSIZE];
 };
+
 #define B_BUSY 0x1  // buffer is locked by some process
 #define B_VALID 0x2 // buffer has been read from disk
 #define B_DIRTY 0x4 // buffer needs to be written to disk

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -2,16 +2,16 @@
 // Input is from the keyboard or serial port.
 // Output is written to the screen and serial port.
 
-#include "kernel/types.h"
 #include "kernel/defs.h"
-#include "kernel/param.h"
-#include "kernel/traps.h"
-#include "kernel/spinlock.h"
-#include "kernel/fs.h"
 #include "kernel/file.h"
+#include "kernel/fs.h"
 #include "kernel/memlayout.h"
 #include "kernel/mmu.h"
+#include "kernel/param.h"
 #include "kernel/proc.h"
+#include "kernel/spinlock.h"
+#include "kernel/traps.h"
+#include "kernel/types.h"
 #include "kernel/x86.h"
 
 static void consputc(int);
@@ -29,7 +29,7 @@ static void printint(int xx, int base, int sign) {
   int i;
   uint x;
 
-  if (sign && (sign = xx < 0))
+  if(sign && (sign = xx < 0))
     x = -xx;
   else
     x = xx;
@@ -37,68 +37,67 @@ static void printint(int xx, int base, int sign) {
   i = 0;
   do {
     buf[i++] = digits[x % base];
-  } while ((x /= base) != 0);
+  } while((x /= base) != 0);
 
-  if (sign)
+  if(sign)
     buf[i++] = '-';
 
-  while (--i >= 0)
+  while(--i >= 0)
     consputc(buf[i]);
 }
-// PAGEBREAK: 50
 
 // Print to the console. only understands %d, %x, %p, %s.
-void cprintf(char *fmt, ...) {
+void cprintf(char* fmt, ...) {
   int i, c, locking;
-  uint *argp;
-  char *s;
+  uint* argp;
+  char* s;
 
   locking = cons.locking;
-  if (locking)
+  if(locking)
     acquire(&cons.lock);
 
-  if (fmt == 0)
+  if(fmt == 0)
     panic("null fmt");
 
-  argp = (uint *)(void *)(&fmt + 1);
-  for (i = 0; (c = fmt[i] & 0xff) != 0; i++) {
-    if (c != '%') {
+  argp = (uint*) (void*) (&fmt + 1);
+  for(i = 0; (c = fmt[i] & 0xff) != 0; i++) {
+    if(c != '%') {
       consputc(c);
       continue;
     }
     c = fmt[++i] & 0xff;
-    if (c == 0)
+    if(c == 0)
       break;
-    switch (c) {
-    case 'd':
-      printint(*argp++, 10, 1);
-      break;
-    case 'x':
-    case 'p':
-      printint(*argp++, 16, 0);
-      break;
-    case 's':
-      if ((s = (char *)*argp++) == 0)
-        s = "(null)";
-      for (; *s; s++)
-        consputc(*s);
-      break;
-    case '%':
-      consputc('%');
-      break;
-    default:
-      // Print unknown % sequence to draw attention.
-      consputc('%');
-      consputc(c);
-      break;
+    switch(c) {
+      case 'd':
+        printint(*argp++, 10, 1);
+        break;
+      case 'x':
+      case 'p':
+        printint(*argp++, 16, 0);
+        break;
+      case 's':
+        if((s = (char*) *argp++) == 0)
+          s = "(null)";
+        for(; *s; s++)
+          consputc(*s);
+        break;
+      case '%':
+        consputc('%');
+        break;
+      default:
+        // Print unknown % sequence to draw attention.
+        consputc('%');
+        consputc(c);
+        break;
     }
   }
 
-  if (locking)
+  if(locking)
     release(&cons.lock);
 }
 
-void panic(char *s) {
+void panic(char* s) {
   int i;
   uint pcs[10];
 
@@ -108,17 +107,15 @@ void panic(char *s) {
   cprintf(s);
   cprintf("\n");
   getcallerpcs(&s, pcs);
-  for (i = 0; i < 10; i++)
+  for(i = 0; i < 10; i++)
     cprintf(" %p", pcs[i]);
   panicked = 1; // freeze other CPU
-  for (;;)
-    ;
+  for(;;) {}
 }
 
-// PAGEBREAK: 50
 #define BACKSPACE 0x100
 #define CRTPORT 0x3d4
-static ushort *crt = (ushort *)P2V(0xb8000); // CGA memory
+static ushort* crt = (ushort*) P2V(0xb8000); // CGA memory
 
 static void cgaputc(int c) {
   int pos;
@@ -129,18 +126,18 @@ static void cgaputc(int c) {
   outb(CRTPORT, 15);
   pos |= inb(CRTPORT + 1);
 
-  if (c == '\n')
+  if(c == '\n')
     pos += 80 - pos % 80;
-  else if (c == BACKSPACE) {
-    if (pos > 0)
+  else if(c == BACKSPACE) {
+    if(pos > 0)
       --pos;
   } else
     crt[pos++] = (c & 0xff) | 0x0700; // black on white
 
-  if (pos < 0 || pos > 25 * 80)
+  if(pos < 0 || pos > 25 * 80)
     panic("pos under/overflow");
 
-  if ((pos / 80) >= 24) { // Scroll up.
+  if((pos / 80) >= 24) { // Scroll up.
     memmove(crt, crt + 80, sizeof(crt[0]) * 23 * 80);
     pos -= 80;
     memset(crt + pos, 0, sizeof(crt[0]) * (24 * 80 - pos));
@@ -154,13 +151,12 @@ static void cgaputc(int c) {
 }
 
 void consputc(int c) {
-  if (panicked) {
+  if(panicked) {
     cli();
-    for (;;)
-      ;
+    for(;;) {}
   }
 
-  if (c == BACKSPACE) {
+  if(c == BACKSPACE) {
     uartputc('\b');
     uartputc(' ');
     uartputc('\b');
@@ -183,54 +179,54 @@ void consoleintr(int (*getc)(void)) {
   int c, doprocdump = 0;
 
   acquire(&cons.lock);
-  while ((c = getc()) >= 0) {
-    switch (c) {
-    case C('P'):      // Process listing.
-      doprocdump = 1; // procdump() locks cons.lock indirectly; invoke later
-      break;
-    case C('U'): // Kill line.
-      while (input.e != input.w &&
-             input.buf[(input.e - 1) % INPUT_BUF] != '\n') {
-        input.e--;
-        consputc(BACKSPACE);
-      }
-      break;
-    case C('H'):
-    case '\x7f': // Backspace
-      if (input.e != input.w) {
-        input.e--;
-        consputc(BACKSPACE);
-      }
-      break;
-    default:
-      if (c != 0 && input.e - input.r < INPUT_BUF) {
-        c = (c == '\r') ? '\n' : c;
-        input.buf[input.e++ % INPUT_BUF] = c;
-        consputc(c);
-        if (c == '\n' || c == C('D') || input.e == input.r + INPUT_BUF) {
-          input.w = input.e;
-          wakeup(&input.r);
+  while((c = getc()) >= 0) {
+    switch(c) {
+      case C('P'):      // Process listing.
+        doprocdump = 1; // procdump() locks cons.lock indirectly; invoke later
+        break;
+      case C('U'): // Kill line.
+        while(input.e != input.w &&
+            input.buf[(input.e - 1) % INPUT_BUF] != '\n') {
+          input.e--;
+          consputc(BACKSPACE);
         }
-      }
-      break;
+        break;
+      case C('H'):
+      case '\x7f': // Backspace
+        if(input.e != input.w) {
+          input.e--;
+          consputc(BACKSPACE);
+        }
+        break;
+      default:
+        if(c != 0 && input.e - input.r < INPUT_BUF) {
+          c = (c == '\r') ? '\n' : c;
+          input.buf[input.e++ % INPUT_BUF] = c;
+          consputc(c);
+          if(c == '\n' || c == C('D') || input.e == input.r + INPUT_BUF) {
+            input.w = input.e;
+            wakeup(&input.r);
+          }
+        }
+        break;
     }
   }
   release(&cons.lock);
-  if (doprocdump) {
+  if(doprocdump) {
     procdump(); // now call procdump() wo. cons.lock held
   }
 }
 
-int consoleread(struct inode *ip, char *dst, int n) {
+int consoleread(struct inode* ip, char* dst, int n) {
   uint target;
   int c;
 
   iunlock(ip);
   target = n;
   acquire(&cons.lock);
-  while (n > 0) {
-    while (input.r == input.w) {
-      if (proc->killed) {
+  while(n > 0) {
+    while(input.r == input.w) {
+      if(proc->killed) {
         release(&cons.lock);
         ilock(ip);
         return -1;
@@ -238,8 +234,8 @@ int consoleread(struct inode *ip, char *dst, int n) {
       sleep(&input.r, &cons.lock);
     }
     c = input.buf[input.r++ % INPUT_BUF];
-    if (c == C('D')) { // EOF
-      if (n < target) {
+    if(c == C('D')) { // EOF
+      if(n < target) {
         // Save ^D for next time, to make sure
         // caller gets a 0-byte result.
         input.r--;
@@ -248,7 +244,7 @@ int consoleread(struct inode *ip, char *dst, int n) {
     }
     *dst++ = c;
     --n;
-    if (c == '\n')
+    if(c == '\n')
       break;
   }
   release(&cons.lock);
@@ -257,12 +253,12 @@ int consoleread(struct inode *ip, char *dst, int n) {
   return target - n;
 }
 
-int consolewrite(struct inode *ip, char *buf, int n) {
+int consolewrite(struct inode* ip, char* buf, int n) {
   int i;
 
   iunlock(ip);
   acquire(&cons.lock);
-  for (i = 0; i < n; i++)
+  for(i = 0; i < n; i++)
     consputc(buf[i] & 0xff);
   release(&cons.lock);
   ilock(ip);

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -17,51 +17,51 @@ struct superblock;
 
 // bio.c
 void binit(void);
-struct buf *bread(uint, uint);
-void brelse(struct buf *);
-void bwrite(struct buf *);
+struct buf* bread(uint, uint);
+void brelse(struct buf*);
+void bwrite(struct buf*);
 
 // console.c
 void consoleinit(void);
-void cprintf(char *, ...);
+void cprintf(char*, ...);
 void consoleintr(int (*)(void));
-void panic(char *) __attribute__((noreturn));
+void panic(char*) __attribute__((noreturn));
 
 // exec.c
-int exec(char *, char **);
+int exec(char*, char**);
 
 // file.c
-struct file *filealloc(void);
-void fileclose(struct file *);
-struct file *filedup(struct file *);
+struct file* filealloc(void);
+void fileclose(struct file*);
+struct file* filedup(struct file*);
 void fileinit(void);
-int fileread(struct file *, char *, int n);
-int filestat(struct file *, struct stat *);
-int filewrite(struct file *, char *, int n);
+int fileread(struct file*, char*, int n);
+int filestat(struct file*, struct stat*);
+int filewrite(struct file*, char*, int n);
 
 // fs.c
-void readsb(int dev, struct superblock *sb);
-int dirlink(struct inode *, char *, uint);
-struct inode *dirlookup(struct inode *, char *, uint *);
-struct inode *ialloc(uint, short);
-struct inode *idup(struct inode *);
+void readsb(int dev, struct superblock* sb);
+int dirlink(struct inode*, char*, uint);
+struct inode* dirlookup(struct inode*, char*, uint*);
+struct inode* ialloc(uint, short);
+struct inode* idup(struct inode*);
 void iinit(int dev);
-void ilock(struct inode *);
-void iput(struct inode *);
-void iunlock(struct inode *);
-void iunlockput(struct inode *);
-void iupdate(struct inode *);
-int namecmp(const char *, const char *);
-struct inode *namei(char *);
-struct inode *nameiparent(char *, char *);
-int readi(struct inode *, char *, uint, uint);
-void stati(struct inode *, struct stat *);
-int writei(struct inode *, char *, uint, uint);
+void ilock(struct inode*);
+void iput(struct inode*);
+void iunlock(struct inode*);
+void iunlockput(struct inode*);
+void iupdate(struct inode*);
+int namecmp(const char*, const char*);
+struct inode* namei(char*);
+struct inode* nameiparent(char*, char*);
+int readi(struct inode*, char*, uint, uint);
+void stati(struct inode*, struct stat*);
+int writei(struct inode*, char*, uint, uint);
 
 // ide.c
 void ideinit(void);
 void ideintr(void);
-void iderw(struct buf *);
+void iderw(struct buf*);
 
 // ioapic.c
 void ioapicenable(int irq, int cpu);
@@ -69,18 +69,18 @@ extern uchar ioapicid;
 void ioapicinit(void);
 
 // kalloc.c
-char *kalloc(void);
-void kfree(char *);
-void kinit1(void *, void *);
-void kinit2(void *, void *);
+char* kalloc(void);
+void kfree(char*);
+void kinit1(void*, void*);
+void kinit2(void*, void*);
 
 // kbd.c
 void kbdintr(void);
 
 // lapic.c
-void cmostime(struct rtcdate *r);
+void cmostime(struct rtcdate* r);
 int cpunum(void);
-extern volatile uint *lapic;
+extern volatile uint* lapic;
 void lapiceoi(void);
 void lapicinit(void);
 void lapicstartap(uchar, uint);
@@ -88,7 +88,7 @@ void microdelay(int);
 
 // log.c
 void initlog(int dev);
-void log_write(struct buf *);
+void log_write(struct buf*);
 void begin_op();
 void end_op();
 
@@ -103,14 +103,13 @@ void picenable(int);
 void picinit(void);
 
 // pipe.c
-int pipealloc(struct file **, struct file **);
-void pipeclose(struct pipe *, int);
-int piperead(struct pipe *, char *, int);
-int pipewrite(struct pipe *, char *, int);
+int pipealloc(struct file**, struct file**);
+void pipeclose(struct pipe*, int);
+int piperead(struct pipe*, char*, int);
+int pipewrite(struct pipe*, char*, int);
 
-// PAGEBREAK: 16
 //  proc.c
-struct proc *copyproc(struct proc *);
+struct proc* copyproc(struct proc*);
 void exit(void);
 int fork(void);
 int growproc(int);
@@ -119,39 +118,39 @@ void pinit(void);
 void procdump(void);
 void scheduler(void) __attribute__((noreturn));
 void sched(void);
-void sleep(void *, struct spinlock *);
+void sleep(void*, struct spinlock*);
 void userinit(void);
 int wait(void);
-void wakeup(void *);
+void wakeup(void*);
 void yield(void);
 
 // swtch.S
-void swtch(struct context **, struct context *);
+void swtch(struct context**, struct context*);
 
 // spinlock.c
-void acquire(struct spinlock *);
-void getcallerpcs(void *, uint *);
-int holding(struct spinlock *);
-void initlock(struct spinlock *, char *);
-void release(struct spinlock *);
+void acquire(struct spinlock*);
+void getcallerpcs(void*, uint*);
+int holding(struct spinlock*);
+void initlock(struct spinlock*, char*);
+void release(struct spinlock*);
 void pushcli(void);
 void popcli(void);
 
 // string.c
-int memcmp(const void *, const void *, uint);
-void *memmove(void *, const void *, uint);
-void *memset(void *, int, uint);
-char *safestrcpy(char *, const char *, int);
-int strlen(const char *);
-int strncmp(const char *, const char *, uint);
-char *strncpy(char *, const char *, int);
+int memcmp(const void*, const void*, uint);
+void* memmove(void*, const void*, uint);
+void* memset(void*, int, uint);
+char* safestrcpy(char*, const char*, int);
+int strlen(const char*);
+int strncmp(const char*, const char*, uint);
+char* strncpy(char*, const char*, int);
 
 // syscall.c
-int argint(int, int *);
-int argptr(int, char **, int);
-int argstr(int, char **);
-int fetchint(uint, int *);
-int fetchstr(uint, char **);
+int argint(int, int*);
+int argptr(int, char**, int);
+int argstr(int, char**);
+int fetchint(uint, int*);
+int fetchstr(uint, char**);
 void syscall(void);
 
 // timer.c
@@ -172,18 +171,18 @@ void uartputc(int);
 void seginit(void);
 void kvmalloc(void);
 void vmenable(void);
-pde_t *setupkvm(void);
-char *uva2ka(pde_t *, char *);
-int allocuvm(pde_t *, uint, uint);
-int deallocuvm(pde_t *, uint, uint);
-void freevm(pde_t *);
-void inituvm(pde_t *, char *, uint);
-int loaduvm(pde_t *, char *, struct inode *, uint, uint);
-pde_t *copyuvm(pde_t *, uint);
-void switchuvm(struct proc *);
+pde_t* setupkvm(void);
+char* uva2ka(pde_t*, char*);
+int allocuvm(pde_t*, uint, uint);
+int deallocuvm(pde_t*, uint, uint);
+void freevm(pde_t*);
+void inituvm(pde_t*, char*, uint);
+int loaduvm(pde_t*, char*, struct inode*, uint, uint);
+pde_t* copyuvm(pde_t*, uint);
+void switchuvm(struct proc*);
 void switchkvm(void);
-int copyout(pde_t *, uint, void *, uint);
-void clearpteu(pde_t *pgdir, char *uva);
+int copyout(pde_t*, uint, void*, uint);
+void clearpteu(pde_t* pgdir, char* uva);
 
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x) / sizeof((x)[0]))

--- a/kernel/entryother.S
+++ b/kernel/entryother.S
@@ -1,7 +1,7 @@
 #include "asm.h"
 #include "kernel/memlayout.h"
 #include "kernel/mmu.h"
-	
+
 # Each non-boot CPU ("AP") is started up in response to a STARTUP
 # IPI from the boot CPU.  Section B.4.2 of the Multi-Processor
 # Specification says that the AP will start in real mode with CS:IP
@@ -21,10 +21,10 @@
 #   - it does not need to enable A20
 #   - it uses the address at start-4, start-8, and start-12
 
-.code16           
+.code16
 .globl start
 start:
-  cli            
+  cli
 
   xorw    %ax,%ax
   movw    %ax,%ds
@@ -36,7 +36,6 @@ start:
   orl     $CR0_PE, %eax
   movl    %eax, %cr0
 
-//PAGEBREAK!
   ljmpl    $(SEG_KCODE<<3), $(start32)
 
 .code32
@@ -84,4 +83,3 @@ gdt:
 gdtdesc:
   .word   (gdtdesc - gdt - 1)
   .long   gdt
-

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -1,23 +1,23 @@
-#include "kernel/types.h"
-#include "kernel/param.h"
+#include "kernel/defs.h"
+#include "kernel/elf.h"
 #include "kernel/memlayout.h"
 #include "kernel/mmu.h"
+#include "kernel/param.h"
 #include "kernel/proc.h"
-#include "kernel/defs.h"
+#include "kernel/types.h"
 #include "kernel/x86.h"
-#include "kernel/elf.h"
 
-int exec(char *path, char **argv) {
+int exec(char* path, char** argv) {
   char *s, *last;
   int i, off;
   uint argc, sz, sp, ustack[3 + MAXARG + 1];
   struct elfhdr elf;
-  struct inode *ip;
+  struct inode* ip;
   struct proghdr ph;
   pde_t *pgdir, *oldpgdir;
 
   begin_op();
-  if ((ip = namei(path)) == 0) {
+  if((ip = namei(path)) == 0) {
     end_op();
     return -1;
   }
@@ -25,26 +25,26 @@ int exec(char *path, char **argv) {
   pgdir = 0;
 
   // Check ELF header
-  if (readi(ip, (char *)&elf, 0, sizeof(elf)) < sizeof(elf))
+  if(readi(ip, (char*) &elf, 0, sizeof(elf)) < sizeof(elf))
     goto bad;
-  if (elf.magic != ELF_MAGIC)
+  if(elf.magic != ELF_MAGIC)
     goto bad;
 
-  if ((pgdir = setupkvm()) == 0)
+  if((pgdir = setupkvm()) == 0)
     goto bad;
 
   // Load program into memory.
   sz = 0;
-  for (i = 0, off = elf.phoff; i < elf.phnum; i++, off += sizeof(ph)) {
-    if (readi(ip, (char *)&ph, off, sizeof(ph)) != sizeof(ph))
+  for(i = 0, off = elf.phoff; i < elf.phnum; i++, off += sizeof(ph)) {
+    if(readi(ip, (char*) &ph, off, sizeof(ph)) != sizeof(ph))
       goto bad;
-    if (ph.type != ELF_PROG_LOAD)
+    if(ph.type != ELF_PROG_LOAD)
       continue;
-    if (ph.memsz < ph.filesz)
+    if(ph.memsz < ph.filesz)
       goto bad;
-    if ((sz = allocuvm(pgdir, sz, ph.vaddr + ph.memsz)) == 0)
+    if((sz = allocuvm(pgdir, sz, ph.vaddr + ph.memsz)) == 0)
       goto bad;
-    if (loaduvm(pgdir, (char *)ph.vaddr, ip, ph.off, ph.filesz) < 0)
+    if(loaduvm(pgdir, (char*) ph.vaddr, ip, ph.off, ph.filesz) < 0)
       goto bad;
   }
   iunlockput(ip);
@@ -54,17 +54,17 @@ int exec(char *path, char **argv) {
   // Allocate two pages at the next page boundary.
   // Make the first inaccessible.  Use the second as the user stack.
   sz = PGROUNDUP(sz);
-  if ((sz = allocuvm(pgdir, sz, sz + 2 * PGSIZE)) == 0)
+  if((sz = allocuvm(pgdir, sz, sz + 2 * PGSIZE)) == 0)
     goto bad;
-  clearpteu(pgdir, (char *)(sz - 2 * PGSIZE));
+  clearpteu(pgdir, (char*) (sz - 2 * PGSIZE));
   sp = sz;
 
   // Push argument strings, prepare rest of stack in ustack.
-  for (argc = 0; argv[argc]; argc++) {
-    if (argc >= MAXARG)
+  for(argc = 0; argv[argc]; argc++) {
+    if(argc >= MAXARG)
       goto bad;
     sp = (sp - (strlen(argv[argc]) + 1)) & ~3;
-    if (copyout(pgdir, sp, argv[argc], strlen(argv[argc]) + 1) < 0)
+    if(copyout(pgdir, sp, argv[argc], strlen(argv[argc]) + 1) < 0)
       goto bad;
     ustack[3 + argc] = sp;
   }
@@ -75,12 +75,12 @@ int exec(char *path, char **argv) {
   ustack[2] = sp - (argc + 1) * 4; // argv pointer
 
   sp -= (3 + argc + 1) * 4;
-  if (copyout(pgdir, sp, ustack, (3 + argc + 1) * 4) < 0)
+  if(copyout(pgdir, sp, ustack, (3 + argc + 1) * 4) < 0)
     goto bad;
 
   // Save program name for debugging.
-  for (last = s = path; *s; s++)
-    if (*s == '/')
+  for(last = s = path; *s; s++)
+    if(*s == '/')
       last = s + 1;
   safestrcpy(proc->name, last, sizeof(proc->name));
 
@@ -95,9 +95,9 @@ int exec(char *path, char **argv) {
   return 0;
 
 bad:
-  if (pgdir)
+  if(pgdir)
     freevm(pgdir);
-  if (ip) {
+  if(ip) {
     iunlockput(ip);
     end_op();
   }

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -2,12 +2,12 @@
 // File descriptors
 //
 
-#include "kernel/types.h"
-#include "kernel/defs.h"
-#include "kernel/param.h"
-#include "kernel/fs.h"
 #include "kernel/file.h"
+#include "kernel/defs.h"
+#include "kernel/fs.h"
+#include "kernel/param.h"
 #include "kernel/spinlock.h"
+#include "kernel/types.h"
 
 struct devsw devsw[NDEV];
 struct {
@@ -15,15 +15,17 @@ struct {
   struct file file[NFILE];
 } ftable;
 
-void fileinit(void) { initlock(&ftable.lock, "ftable"); }
+void fileinit(void) {
+  initlock(&ftable.lock, "ftable");
+}
 
 // Allocate a file structure.
-struct file *filealloc(void) {
-  struct file *f;
+struct file* filealloc(void) {
+  struct file* f;
 
   acquire(&ftable.lock);
-  for (f = ftable.file; f < ftable.file + NFILE; f++) {
-    if (f->ref == 0) {
+  for(f = ftable.file; f < ftable.file + NFILE; f++) {
+    if(f->ref == 0) {
       f->ref = 1;
       release(&ftable.lock);
       return f;
@@ -34,9 +36,9 @@ struct file *filealloc(void) {
 }
 
 // Increment ref count for file f.
-struct file *filedup(struct file *f) {
+struct file* filedup(struct file* f) {
   acquire(&ftable.lock);
-  if (f->ref < 1)
+  if(f->ref < 1)
     panic("filedup");
   f->ref++;
   release(&ftable.lock);
@@ -44,13 +46,13 @@ struct file *filedup(struct file *f) {
 }
 
 // Close file f.  (Decrement ref count, close when reaches 0.)
-void fileclose(struct file *f) {
+void fileclose(struct file* f) {
   struct file ff;
 
   acquire(&ftable.lock);
-  if (f->ref < 1)
+  if(f->ref < 1)
     panic("fileclose");
-  if (--f->ref > 0) {
+  if(--f->ref > 0) {
     release(&ftable.lock);
     return;
   }
@@ -59,9 +61,9 @@ void fileclose(struct file *f) {
   f->type = FD_NONE;
   release(&ftable.lock);
 
-  if (ff.type == FD_PIPE)
+  if(ff.type == FD_PIPE)
     pipeclose(ff.pipe, ff.writable);
-  else if (ff.type == FD_INODE) {
+  else if(ff.type == FD_INODE) {
     begin_op();
     iput(ff.ip);
     end_op();
@@ -69,8 +71,8 @@ void fileclose(struct file *f) {
 }
 
 // Get metadata about file f.
-int filestat(struct file *f, struct stat *st) {
-  if (f->type == FD_INODE) {
+int filestat(struct file* f, struct stat* st) {
+  if(f->type == FD_INODE) {
     ilock(f->ip);
     stati(f->ip, st);
     iunlock(f->ip);
@@ -80,16 +82,16 @@ int filestat(struct file *f, struct stat *st) {
 }
 
 // Read from file f.
-int fileread(struct file *f, char *addr, int n) {
+int fileread(struct file* f, char* addr, int n) {
   int r;
 
-  if (f->readable == 0)
+  if(f->readable == 0)
     return -1;
-  if (f->type == FD_PIPE)
+  if(f->type == FD_PIPE)
     return piperead(f->pipe, addr, n);
-  if (f->type == FD_INODE) {
+  if(f->type == FD_INODE) {
     ilock(f->ip);
-    if ((r = readi(f->ip, addr, f->off, n)) > 0)
+    if((r = readi(f->ip, addr, f->off, n)) > 0)
       f->off += r;
     iunlock(f->ip);
     return r;
@@ -97,16 +99,15 @@ int fileread(struct file *f, char *addr, int n) {
   panic("fileread");
 }
 
-// PAGEBREAK!
 // Write to file f.
-int filewrite(struct file *f, char *addr, int n) {
+int filewrite(struct file* f, char* addr, int n) {
   int r;
 
-  if (f->writable == 0)
+  if(f->writable == 0)
     return -1;
-  if (f->type == FD_PIPE)
+  if(f->type == FD_PIPE)
     return pipewrite(f->pipe, addr, n);
-  if (f->type == FD_INODE) {
+  if(f->type == FD_INODE) {
     // write a few blocks at a time to avoid exceeding
     // the maximum log transaction size, including
     // i-node, indirect block, allocation blocks,
@@ -115,21 +116,21 @@ int filewrite(struct file *f, char *addr, int n) {
     // might be writing a device like the console.
     int max = ((LOGSIZE - 1 - 1 - 2) / 2) * 512;
     int i = 0;
-    while (i < n) {
+    while(i < n) {
       int n1 = n - i;
-      if (n1 > max)
+      if(n1 > max)
         n1 = max;
 
       begin_op();
       ilock(f->ip);
-      if ((r = writei(f->ip, addr + i, f->off, n1)) > 0)
+      if((r = writei(f->ip, addr + i, f->off, n1)) > 0)
         f->off += r;
       iunlock(f->ip);
       end_op();
 
-      if (r < 0)
+      if(r < 0)
         break;
-      if (r != n1)
+      if(r != n1)
         panic("short filewrite");
       i += r;
     }

--- a/kernel/file.h
+++ b/kernel/file.h
@@ -1,16 +1,17 @@
 #ifndef XV6_FILE_H
 #define XV6_FILE_H
 
-#include "types.h"
 #include "defs.h"
+#include "fs.h"
+#include "types.h"
 
 struct file {
   enum { FD_NONE, FD_PIPE, FD_INODE } type;
   int ref; // reference count
   char readable;
   char writable;
-  struct pipe *pipe;
-  struct inode *ip;
+  struct pipe* pipe;
+  struct inode* ip;
   uint off;
 };
 
@@ -34,15 +35,12 @@ struct inode {
 // table mapping major device number to
 // device functions
 struct devsw {
-  int (*read)(struct inode *, char *, int);
-  int (*write)(struct inode *, char *, int);
+  int (*read)(struct inode*, char*, int);
+  int (*write)(struct inode*, char*, int);
 };
 
 extern struct devsw devsw[];
 
 #define CONSOLE 1
-
-// PAGEBREAK!
-//  Blank page.
 
 #endif // XV6_FILE_H

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -9,24 +9,24 @@
 // routines.  The (higher-level) system call implementations
 // are in sysfile.c.
 
-#include "kernel/types.h"
-#include "kernel/defs.h"
-#include "kernel/param.h"
-#include "kernel/stat.h"
-#include "kernel/mmu.h"
-#include "kernel/proc.h"
-#include "kernel/spinlock.h"
 #include "kernel/fs.h"
 #include "buf.h"
+#include "kernel/defs.h"
 #include "kernel/file.h"
+#include "kernel/mmu.h"
+#include "kernel/param.h"
+#include "kernel/proc.h"
+#include "kernel/spinlock.h"
+#include "kernel/stat.h"
+#include "kernel/types.h"
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
-static void itrunc(struct inode *);
+static void itrunc(struct inode*);
 struct superblock sb; // there should be one per dev, but we run with one dev
 
 // Read the super block.
-void readsb(int dev, struct superblock *sb) {
-  struct buf *bp;
+void readsb(int dev, struct superblock* sb) {
+  struct buf* bp;
 
   bp = bread(dev, 1);
   memmove(sb, bp->data, sizeof(*sb));
@@ -35,7 +35,7 @@ void readsb(int dev, struct superblock *sb) {
 
 // Zero a block.
 static void bzero(int dev, int bno) {
-  struct buf *bp;
+  struct buf* bp;
 
   bp = bread(dev, bno);
   memset(bp->data, 0, BSIZE);
@@ -48,15 +48,15 @@ static void bzero(int dev, int bno) {
 // Allocate a zeroed disk block.
 static uint balloc(uint dev) {
   int b, bi, m;
-  struct buf *bp;
+  struct buf* bp;
 
   bp = 0;
-  for (b = 0; b < sb.size; b += BPB) {
+  for(b = 0; b < sb.size; b += BPB) {
     bp = bread(dev, BBLOCK(b, sb));
-    for (bi = 0; bi < BPB && b + bi < sb.size; bi++) {
+    for(bi = 0; bi < BPB && b + bi < sb.size; bi++) {
       m = 1 << (bi % 8);
-      if ((bp->data[bi / 8] & m) == 0) { // Is block free?
-        bp->data[bi / 8] |= m;           // Mark block in use.
+      if((bp->data[bi / 8] & m) == 0) { // Is block free?
+        bp->data[bi / 8] |= m;          // Mark block in use.
         log_write(bp);
         brelse(bp);
         bzero(dev, b + bi);
@@ -70,14 +70,14 @@ static uint balloc(uint dev) {
 
 // Free a disk block.
 static void bfree(int dev, uint b) {
-  struct buf *bp;
+  struct buf* bp;
   int bi, m;
 
   readsb(dev, &sb);
   bp = bread(dev, BBLOCK(b, sb));
   bi = b % BPB;
   m = 1 << (bi % 8);
-  if ((bp->data[bi / 8] & m) == 0)
+  if((bp->data[bi / 8] & m) == 0)
     panic("freeing free block");
   bp->data[bi / 8] &= ~m;
   log_write(bp);
@@ -154,26 +154,26 @@ struct {
 void iinit(int dev) {
   initlock(&icache.lock, "icache");
   readsb(dev, &sb);
-  cprintf("sb: size %d nblocks %d ninodes %d nlog %d logstart %d inodestart %d "
-          "bmap start %d\n",
-          sb.size, sb.nblocks, sb.ninodes, sb.nlog, sb.logstart, sb.inodestart,
-          sb.bmapstart);
+  cprintf(
+      "sb: size %d nblocks %d ninodes %d nlog %d logstart %d inodestart %d "
+      "bmap start %d\n",
+      sb.size, sb.nblocks, sb.ninodes, sb.nlog, sb.logstart, sb.inodestart,
+      sb.bmapstart);
 }
 
-static struct inode *iget(uint dev, uint inum);
+static struct inode* iget(uint dev, uint inum);
 
-// PAGEBREAK!
 // Allocate a new inode with the given type on device dev.
 // A free inode has a type of zero.
-struct inode *ialloc(uint dev, short type) {
+struct inode* ialloc(uint dev, short type) {
   int inum;
-  struct buf *bp;
-  struct dinode *dip;
+  struct buf* bp;
+  struct dinode* dip;
 
-  for (inum = 1; inum < sb.ninodes; inum++) {
+  for(inum = 1; inum < sb.ninodes; inum++) {
     bp = bread(dev, IBLOCK(inum, sb));
-    dip = (struct dinode *)bp->data + inum % IPB;
-    if (dip->type == 0) { // a free inode
+    dip = (struct dinode*) bp->data + inum % IPB;
+    if(dip->type == 0) { // a free inode
       memset(dip, 0, sizeof(*dip));
       dip->type = type;
       log_write(bp); // mark it allocated on the disk
@@ -186,12 +186,12 @@ struct inode *ialloc(uint dev, short type) {
 }
 
 // Copy a modified in-memory inode to disk.
-void iupdate(struct inode *ip) {
-  struct buf *bp;
-  struct dinode *dip;
+void iupdate(struct inode* ip) {
+  struct buf* bp;
+  struct dinode* dip;
 
   bp = bread(ip->dev, IBLOCK(ip->inum, sb));
-  dip = (struct dinode *)bp->data + ip->inum % IPB;
+  dip = (struct dinode*) bp->data + ip->inum % IPB;
   dip->type = ip->type;
   dip->major = ip->major;
   dip->minor = ip->minor;
@@ -205,25 +205,25 @@ void iupdate(struct inode *ip) {
 // Find the inode with number inum on device dev
 // and return the in-memory copy. Does not lock
 // the inode and does not read it from disk.
-static struct inode *iget(uint dev, uint inum) {
+static struct inode* iget(uint dev, uint inum) {
   struct inode *ip, *empty;
 
   acquire(&icache.lock);
 
   // Is the inode already cached?
   empty = 0;
-  for (ip = &icache.inode[0]; ip < &icache.inode[NINODE]; ip++) {
-    if (ip->ref > 0 && ip->dev == dev && ip->inum == inum) {
+  for(ip = &icache.inode[0]; ip < &icache.inode[NINODE]; ip++) {
+    if(ip->ref > 0 && ip->dev == dev && ip->inum == inum) {
       ip->ref++;
       release(&icache.lock);
       return ip;
     }
-    if (empty == 0 && ip->ref == 0) // Remember empty slot.
+    if(empty == 0 && ip->ref == 0) // Remember empty slot.
       empty = ip;
   }
 
   // Recycle an inode cache entry.
-  if (empty == 0)
+  if(empty == 0)
     panic("iget: no inodes");
 
   ip = empty;
@@ -238,7 +238,7 @@ static struct inode *iget(uint dev, uint inum) {
 
 // Increment reference count for ip.
 // Returns ip to enable ip = idup(ip1) idiom.
-struct inode *idup(struct inode *ip) {
+struct inode* idup(struct inode* ip) {
   acquire(&icache.lock);
   ip->ref++;
   release(&icache.lock);
@@ -247,22 +247,22 @@ struct inode *idup(struct inode *ip) {
 
 // Lock the given inode.
 // Reads the inode from disk if necessary.
-void ilock(struct inode *ip) {
-  struct buf *bp;
-  struct dinode *dip;
+void ilock(struct inode* ip) {
+  struct buf* bp;
+  struct dinode* dip;
 
-  if (ip == 0 || ip->ref < 1)
+  if(ip == 0 || ip->ref < 1)
     panic("ilock");
 
   acquire(&icache.lock);
-  while (ip->flags & I_BUSY)
+  while(ip->flags & I_BUSY)
     sleep(ip, &icache.lock);
   ip->flags |= I_BUSY;
   release(&icache.lock);
 
-  if (!(ip->flags & I_VALID)) {
+  if(!(ip->flags & I_VALID)) {
     bp = bread(ip->dev, IBLOCK(ip->inum, sb));
-    dip = (struct dinode *)bp->data + ip->inum % IPB;
+    dip = (struct dinode*) bp->data + ip->inum % IPB;
     ip->type = dip->type;
     ip->major = dip->major;
     ip->minor = dip->minor;
@@ -271,14 +271,14 @@ void ilock(struct inode *ip) {
     memmove(ip->addrs, dip->addrs, sizeof(ip->addrs));
     brelse(bp);
     ip->flags |= I_VALID;
-    if (ip->type == 0)
+    if(ip->type == 0)
       panic("ilock: no type");
   }
 }
 
 // Unlock the given inode.
-void iunlock(struct inode *ip) {
-  if (ip == 0 || !(ip->flags & I_BUSY) || ip->ref < 1)
+void iunlock(struct inode* ip) {
+  if(ip == 0 || !(ip->flags & I_BUSY) || ip->ref < 1)
     panic("iunlock");
 
   acquire(&icache.lock);
@@ -294,11 +294,11 @@ void iunlock(struct inode *ip) {
 // to it, free the inode (and its content) on disk.
 // All calls to iput() must be inside a transaction in
 // case it has to free the inode.
-void iput(struct inode *ip) {
+void iput(struct inode* ip) {
   acquire(&icache.lock);
-  if (ip->ref == 1 && (ip->flags & I_VALID) && ip->nlink == 0) {
+  if(ip->ref == 1 && (ip->flags & I_VALID) && ip->nlink == 0) {
     // inode has no links and no other references: truncate and free.
-    if (ip->flags & I_BUSY)
+    if(ip->flags & I_BUSY)
       panic("iput busy");
     ip->flags |= I_BUSY;
     release(&icache.lock);
@@ -314,12 +314,11 @@ void iput(struct inode *ip) {
 }
 
 // Common idiom: unlock, then put.
-void iunlockput(struct inode *ip) {
+void iunlockput(struct inode* ip) {
   iunlock(ip);
   iput(ip);
 }
 
-// PAGEBREAK!
 // Inode content
 //
 // The content (data) associated with each inode is stored
@@ -329,24 +328,24 @@ void iunlockput(struct inode *ip) {
 
 // Return the disk block address of the nth block in inode ip.
 // If there is no such block, bmap allocates one.
-static uint bmap(struct inode *ip, uint bn) {
+static uint bmap(struct inode* ip, uint bn) {
   uint addr, *a;
-  struct buf *bp;
+  struct buf* bp;
 
-  if (bn < NDIRECT) {
-    if ((addr = ip->addrs[bn]) == 0)
+  if(bn < NDIRECT) {
+    if((addr = ip->addrs[bn]) == 0)
       ip->addrs[bn] = addr = balloc(ip->dev);
     return addr;
   }
   bn -= NDIRECT;
 
-  if (bn < NINDIRECT) {
+  if(bn < NINDIRECT) {
     // Load indirect block, allocating if necessary.
-    if ((addr = ip->addrs[NDIRECT]) == 0)
+    if((addr = ip->addrs[NDIRECT]) == 0)
       ip->addrs[NDIRECT] = addr = balloc(ip->dev);
     bp = bread(ip->dev, addr);
-    a = (uint *)bp->data;
-    if ((addr = a[bn]) == 0) {
+    a = (uint*) bp->data;
+    if((addr = a[bn]) == 0) {
       a[bn] = addr = balloc(ip->dev);
       log_write(bp);
     }
@@ -362,23 +361,23 @@ static uint bmap(struct inode *ip, uint bn) {
 // to it (no directory entries referring to it)
 // and has no in-memory reference to it (is
 // not an open file or current directory).
-static void itrunc(struct inode *ip) {
+static void itrunc(struct inode* ip) {
   int i, j;
-  struct buf *bp;
-  uint *a;
+  struct buf* bp;
+  uint* a;
 
-  for (i = 0; i < NDIRECT; i++) {
-    if (ip->addrs[i]) {
+  for(i = 0; i < NDIRECT; i++) {
+    if(ip->addrs[i]) {
       bfree(ip->dev, ip->addrs[i]);
       ip->addrs[i] = 0;
     }
   }
 
-  if (ip->addrs[NDIRECT]) {
+  if(ip->addrs[NDIRECT]) {
     bp = bread(ip->dev, ip->addrs[NDIRECT]);
-    a = (uint *)bp->data;
-    for (j = 0; j < NINDIRECT; j++) {
-      if (a[j])
+    a = (uint*) bp->data;
+    for(j = 0; j < NINDIRECT; j++) {
+      if(a[j])
         bfree(ip->dev, a[j]);
     }
     brelse(bp);
@@ -391,7 +390,7 @@ static void itrunc(struct inode *ip) {
 }
 
 // Copy stat information from inode.
-void stati(struct inode *ip, struct stat *st) {
+void stati(struct inode* ip, struct stat* st) {
   st->dev = ip->dev;
   st->ino = ip->inum;
   st->type = ip->type;
@@ -399,24 +398,23 @@ void stati(struct inode *ip, struct stat *st) {
   st->size = ip->size;
 }
 
-// PAGEBREAK!
 // Read data from inode.
-int readi(struct inode *ip, char *dst, uint off, uint n) {
+int readi(struct inode* ip, char* dst, uint off, uint n) {
   uint tot, m;
-  struct buf *bp;
+  struct buf* bp;
 
-  if (ip->type == T_DEV) {
-    if (ip->major < 0 || ip->major >= NDEV || !devsw[ip->major].read)
+  if(ip->type == T_DEV) {
+    if(ip->major < 0 || ip->major >= NDEV || !devsw[ip->major].read)
       return -1;
     return devsw[ip->major].read(ip, dst, n);
   }
 
-  if (off > ip->size || off + n < off)
+  if(off > ip->size || off + n < off)
     return -1;
-  if (off + n > ip->size)
+  if(off + n > ip->size)
     n = ip->size - off;
 
-  for (tot = 0; tot < n; tot += m, off += m, dst += m) {
+  for(tot = 0; tot < n; tot += m, off += m, dst += m) {
     bp = bread(ip->dev, bmap(ip, off / BSIZE));
     m = min(n - tot, BSIZE - off % BSIZE);
     memmove(dst, bp->data + off % BSIZE, m);
@@ -425,24 +423,23 @@ int readi(struct inode *ip, char *dst, uint off, uint n) {
   return n;
 }
 
-// PAGEBREAK!
 // Write data to inode.
-int writei(struct inode *ip, char *src, uint off, uint n) {
+int writei(struct inode* ip, char* src, uint off, uint n) {
   uint tot, m;
-  struct buf *bp;
+  struct buf* bp;
 
-  if (ip->type == T_DEV) {
-    if (ip->major < 0 || ip->major >= NDEV || !devsw[ip->major].write)
+  if(ip->type == T_DEV) {
+    if(ip->major < 0 || ip->major >= NDEV || !devsw[ip->major].write)
       return -1;
     return devsw[ip->major].write(ip, src, n);
   }
 
-  if (off > ip->size || off + n < off)
+  if(off > ip->size || off + n < off)
     return -1;
-  if (off + n > MAXFILE * BSIZE)
+  if(off + n > MAXFILE * BSIZE)
     return -1;
 
-  for (tot = 0; tot < n; tot += m, off += m, src += m) {
+  for(tot = 0; tot < n; tot += m, off += m, src += m) {
     bp = bread(ip->dev, bmap(ip, off / BSIZE));
     m = min(n - tot, BSIZE - off % BSIZE);
     memmove(bp->data + off % BSIZE, src, m);
@@ -450,35 +447,36 @@ int writei(struct inode *ip, char *src, uint off, uint n) {
     brelse(bp);
   }
 
-  if (n > 0 && off > ip->size) {
+  if(n > 0 && off > ip->size) {
     ip->size = off;
     iupdate(ip);
   }
   return n;
 }
 
-// PAGEBREAK!
 // Directories
 
-int namecmp(const char *s, const char *t) { return strncmp(s, t, DIRSIZ); }
+int namecmp(const char* s, const char* t) {
+  return strncmp(s, t, DIRSIZ);
+}
 
 // Look for a directory entry in a directory.
 // If found, set *poff to byte offset of entry.
-struct inode *dirlookup(struct inode *dp, char *name, uint *poff) {
+struct inode* dirlookup(struct inode* dp, char* name, uint* poff) {
   uint off, inum;
   struct dirent de;
 
-  if (dp->type != T_DIR)
+  if(dp->type != T_DIR)
     panic("dirlookup not DIR");
 
-  for (off = 0; off < dp->size; off += sizeof(de)) {
-    if (readi(dp, (char *)&de, off, sizeof(de)) != sizeof(de))
+  for(off = 0; off < dp->size; off += sizeof(de)) {
+    if(readi(dp, (char*) &de, off, sizeof(de)) != sizeof(de))
       panic("dirlink read");
-    if (de.inum == 0)
+    if(de.inum == 0)
       continue;
-    if (namecmp(name, de.name) == 0) {
+    if(namecmp(name, de.name) == 0) {
       // entry matches path element
-      if (poff)
+      if(poff)
         *poff = off;
       inum = de.inum;
       return iget(dp->dev, inum);
@@ -489,34 +487,33 @@ struct inode *dirlookup(struct inode *dp, char *name, uint *poff) {
 }
 
 // Write a new directory entry (name, inum) into the directory dp.
-int dirlink(struct inode *dp, char *name, uint inum) {
+int dirlink(struct inode* dp, char* name, uint inum) {
   int off;
   struct dirent de;
-  struct inode *ip;
+  struct inode* ip;
 
   // Check that name is not present.
-  if ((ip = dirlookup(dp, name, 0)) != 0) {
+  if((ip = dirlookup(dp, name, 0)) != 0) {
     iput(ip);
     return -1;
   }
 
   // Look for an empty dirent.
-  for (off = 0; off < dp->size; off += sizeof(de)) {
-    if (readi(dp, (char *)&de, off, sizeof(de)) != sizeof(de))
+  for(off = 0; off < dp->size; off += sizeof(de)) {
+    if(readi(dp, (char*) &de, off, sizeof(de)) != sizeof(de))
       panic("dirlink read");
-    if (de.inum == 0)
+    if(de.inum == 0)
       break;
   }
 
   strncpy(de.name, name, DIRSIZ);
   de.inum = inum;
-  if (writei(dp, (char *)&de, off, sizeof(de)) != sizeof(de))
+  if(writei(dp, (char*) &de, off, sizeof(de)) != sizeof(de))
     panic("dirlink");
 
   return 0;
 }
 
-// PAGEBREAK!
 // Paths
 
 // Copy the next path element from path into name.
@@ -531,25 +528,25 @@ int dirlink(struct inode *dp, char *name, uint inum) {
 //   skipelem("a", name) = "", setting name = "a"
 //   skipelem("", name) = skipelem("////", name) = 0
 //
-static char *skipelem(char *path, char *name) {
-  char *s;
+static char* skipelem(char* path, char* name) {
+  char* s;
   int len;
 
-  while (*path == '/')
+  while(*path == '/')
     path++;
-  if (*path == 0)
+  if(*path == 0)
     return 0;
   s = path;
-  while (*path != '/' && *path != 0)
+  while(*path != '/' && *path != 0)
     path++;
   len = path - s;
-  if (len >= DIRSIZ)
+  if(len >= DIRSIZ)
     memmove(name, s, DIRSIZ);
   else {
     memmove(name, s, len);
     name[len] = 0;
   }
-  while (*path == '/')
+  while(*path == '/')
     path++;
   return path;
 }
@@ -558,44 +555,44 @@ static char *skipelem(char *path, char *name) {
 // If parent != 0, return the inode for the parent and copy the final
 // path element into name, which must have room for DIRSIZ bytes.
 // Must be called inside a transaction since it calls iput().
-static struct inode *namex(char *path, int nameiparent, char *name) {
+static struct inode* namex(char* path, int nameiparent, char* name) {
   struct inode *ip, *next;
 
-  if (*path == '/')
+  if(*path == '/')
     ip = iget(ROOTDEV, ROOTINO);
   else
     ip = idup(proc->cwd);
 
-  while ((path = skipelem(path, name)) != 0) {
+  while((path = skipelem(path, name)) != 0) {
     ilock(ip);
-    if (ip->type != T_DIR) {
+    if(ip->type != T_DIR) {
       iunlockput(ip);
       return 0;
     }
-    if (nameiparent && *path == '\0') {
+    if(nameiparent && *path == '\0') {
       // Stop one level early.
       iunlock(ip);
       return ip;
     }
-    if ((next = dirlookup(ip, name, 0)) == 0) {
+    if((next = dirlookup(ip, name, 0)) == 0) {
       iunlockput(ip);
       return 0;
     }
     iunlockput(ip);
     ip = next;
   }
-  if (nameiparent) {
+  if(nameiparent) {
     iput(ip);
     return 0;
   }
   return ip;
 }
 
-struct inode *namei(char *path) {
+struct inode* namei(char* path) {
   char name[DIRSIZ];
   return namex(path, 0, name);
 }
 
-struct inode *nameiparent(char *path, char *name) {
+struct inode* nameiparent(char* path, char* name) {
   return namex(path, 1, name);
 }

--- a/kernel/fs.h
+++ b/kernel/fs.h
@@ -10,8 +10,7 @@
 #define BSIZE 512 // block size
 
 // Disk layout:
-// [ boot block | super block | log | inode blocks | free bit map | data blocks
-// ]
+// [ boot block | super block | log | inode blocks | free bitmap | data blocks ]
 //
 // mkfs computes the super block and builds an initial file system. The super
 // describes the disk layout:

--- a/kernel/ioapic.c
+++ b/kernel/ioapic.c
@@ -2,9 +2,9 @@
 // http://www.intel.com/design/chipsets/datashts/29056601.pdf
 // See also picirq.c.
 
-#include "kernel/types.h"
 #include "kernel/defs.h"
 #include "kernel/traps.h"
+#include "kernel/types.h"
 
 #define IOAPIC 0xFEC00000 // Default physical address of IO APIC
 
@@ -22,7 +22,7 @@
 #define INT_ACTIVELOW 0x00002000 // Active low (vs high)
 #define INT_LOGICAL 0x00000800   // Destination is CPU id (vs APIC ID)
 
-volatile struct ioapic *ioapic;
+volatile struct ioapic* ioapic;
 
 // IO APIC MMIO structure: write reg, then read or write data.
 struct ioapic {
@@ -44,25 +44,25 @@ static void ioapicwrite(int reg, uint data) {
 void ioapicinit(void) {
   int i, id, maxintr;
 
-  if (!ismp)
+  if(!ismp)
     return;
 
-  ioapic = (volatile struct ioapic *)IOAPIC;
+  ioapic = (volatile struct ioapic*) IOAPIC;
   maxintr = (ioapicread(REG_VER) >> 16) & 0xFF;
   id = ioapicread(REG_ID) >> 24;
-  if (id != ioapicid)
+  if(id != ioapicid)
     cprintf("ioapicinit: id isn't equal to ioapicid; not a MP\n");
 
   // Mark all interrupts edge-triggered, active high, disabled,
   // and not routed to any CPUs.
-  for (i = 0; i <= maxintr; i++) {
+  for(i = 0; i <= maxintr; i++) {
     ioapicwrite(REG_TABLE + 2 * i, INT_DISABLED | (T_IRQ0 + i));
     ioapicwrite(REG_TABLE + 2 * i + 1, 0);
   }
 }
 
 void ioapicenable(int irq, int cpunum) {
-  if (!ismp)
+  if(!ismp)
     return;
 
   // Mark interrupt edge-triggered, active high,

--- a/kernel/kalloc.c
+++ b/kernel/kalloc.c
@@ -2,24 +2,24 @@
 // memory for user processes, kernel stacks, page table pages,
 // and pipe buffers. Allocates 4096-byte pages.
 
-#include "kernel/types.h"
 #include "kernel/defs.h"
-#include "kernel/param.h"
 #include "kernel/memlayout.h"
 #include "kernel/mmu.h"
+#include "kernel/param.h"
 #include "kernel/spinlock.h"
+#include "kernel/types.h"
 
-void freerange(void *vstart, void *vend);
+void freerange(void* vstart, void* vend);
 extern char end[]; // first address after kernel loaded from ELF file
 
 struct run {
-  struct run *next;
+  struct run* next;
 };
 
 struct {
   struct spinlock lock;
   int use_lock;
-  struct run *freelist;
+  struct run* freelist;
 } kmem;
 
 // Initialization happens in two phases.
@@ -27,59 +27,58 @@ struct {
 // the pages mapped by entrypgdir on free list.
 // 2. main() calls kinit2() with the rest of the physical pages
 // after installing a full page table that maps them on all cores.
-void kinit1(void *vstart, void *vend) {
+void kinit1(void* vstart, void* vend) {
   initlock(&kmem.lock, "kmem");
   kmem.use_lock = 0;
   freerange(vstart, vend);
 }
 
-void kinit2(void *vstart, void *vend) {
+void kinit2(void* vstart, void* vend) {
   freerange(vstart, vend);
   kmem.use_lock = 1;
 }
 
-void freerange(void *vstart, void *vend) {
-  char *p;
-  p = (char *)PGROUNDUP((uint)vstart);
-  for (; p + PGSIZE <= (char *)vend; p += PGSIZE)
+void freerange(void* vstart, void* vend) {
+  char* p;
+  p = (char*) PGROUNDUP((uint) vstart);
+  for(; p + PGSIZE <= (char*) vend; p += PGSIZE)
     kfree(p);
 }
 
-// PAGEBREAK: 21
 // Free the page of physical memory pointed at by v,
 // which normally should have been returned by a
 // call to kalloc().  (The exception is when
 // initializing the allocator; see kinit above.)
-void kfree(char *v) {
-  struct run *r;
+void kfree(char* v) {
+  struct run* r;
 
-  if ((uint)v % PGSIZE || v < end || v2p(v) >= PHYSTOP)
+  if((uint) v % PGSIZE || v < end || v2p(v) >= PHYSTOP)
     panic("kfree");
 
   // Fill with junk to catch dangling refs.
   memset(v, 1, PGSIZE);
 
-  if (kmem.use_lock)
+  if(kmem.use_lock)
     acquire(&kmem.lock);
-  r = (struct run *)v;
+  r = (struct run*) v;
   r->next = kmem.freelist;
   kmem.freelist = r;
-  if (kmem.use_lock)
+  if(kmem.use_lock)
     release(&kmem.lock);
 }
 
 // Allocate one 4096-byte page of physical memory.
 // Returns a pointer that the kernel can use.
 // Returns 0 if the memory cannot be allocated.
-char *kalloc(void) {
-  struct run *r;
+char* kalloc(void) {
+  struct run* r;
 
-  if (kmem.use_lock)
+  if(kmem.use_lock)
     acquire(&kmem.lock);
   r = kmem.freelist;
-  if (r)
+  if(r)
     kmem.freelist = r->next;
-  if (kmem.use_lock)
+  if(kmem.use_lock)
     release(&kmem.lock);
-  return (char *)r;
+  return (char*) r;
 }

--- a/kernel/kbd.c
+++ b/kernel/kbd.c
@@ -1,27 +1,27 @@
+#include "kernel/kbd.h"
+#include "kernel/defs.h"
 #include "kernel/types.h"
 #include "kernel/x86.h"
-#include "kernel/defs.h"
-#include "kernel/kbd.h"
 
 int kbdgetc(void) {
   static uint shift;
-  static uchar *charcode[4] = {normalmap, shiftmap, ctlmap, ctlmap};
+  static uchar* charcode[4] = {normalmap, shiftmap, ctlmap, ctlmap};
   uint st, data, c;
 
   st = inb(KBSTATP);
-  if ((st & KBS_DIB) == 0)
+  if((st & KBS_DIB) == 0)
     return -1;
   data = inb(KBDATAP);
 
-  if (data == 0xE0) {
+  if(data == 0xE0) {
     shift |= E0ESC;
     return 0;
-  } else if (data & 0x80) {
+  } else if(data & 0x80) {
     // Key released
     data = (shift & E0ESC ? data : data & 0x7F);
     shift &= ~(shiftcode[data] | E0ESC);
     return 0;
-  } else if (shift & E0ESC) {
+  } else if(shift & E0ESC) {
     // Last character was an E0 escape; or with 0x80
     data |= 0x80;
     shift &= ~E0ESC;
@@ -30,13 +30,15 @@ int kbdgetc(void) {
   shift |= shiftcode[data];
   shift ^= togglecode[data];
   c = charcode[shift & (CTL | SHIFT)][data];
-  if (shift & CAPSLOCK) {
-    if ('a' <= c && c <= 'z')
+  if(shift & CAPSLOCK) {
+    if('a' <= c && c <= 'z')
       c += 'A' - 'a';
-    else if ('A' <= c && c <= 'Z')
+    else if('A' <= c && c <= 'Z')
       c += 'a' - 'A';
   }
   return c;
 }
 
-void kbdintr(void) { consoleintr(kbdgetc); }
+void kbdintr(void) {
+  consoleintr(kbdgetc);
+}

--- a/kernel/kbd.h
+++ b/kernel/kbd.h
@@ -37,7 +37,12 @@
 #define C(x) (x - '@')
 
 static uchar shiftcode[256] = {
-    [0x1D] CTL, [0x2A] SHIFT, [0x36] SHIFT, [0x38] ALT, [0x9D] CTL, [0xB8] ALT,
+    [0x1D] CTL,
+    [0x2A] SHIFT,
+    [0x36] SHIFT,
+    [0x38] ALT,
+    [0x9D] CTL,
+    [0xB8] ALT,
 };
 
 static uchar togglecode[256] = {

--- a/kernel/lapic.c
+++ b/kernel/lapic.c
@@ -1,12 +1,12 @@
 // The local APIC manages internal (non-I/O) interrupts.
 // See Chapter 8 & Appendix C of Intel processor manual volume 3.
 
-#include "kernel/types.h"
-#include "kernel/defs.h"
 #include "kernel/date.h"
+#include "kernel/defs.h"
 #include "kernel/memlayout.h"
-#include "kernel/traps.h"
 #include "kernel/mmu.h"
+#include "kernel/traps.h"
+#include "kernel/types.h"
 #include "kernel/x86.h"
 
 // Local APIC registers, divided by 4 for use as uint[] indices.
@@ -40,16 +40,15 @@
 #define TCCR (0x0390 / 4)   // Timer Current Count
 #define TDCR (0x03E0 / 4)   // Timer Divide Configuration
 
-volatile uint *lapic; // Initialized in mp.c
+volatile uint* lapic; // Initialized in mp.c
 
 static void lapicw(int index, int value) {
   lapic[index] = value;
   lapic[ID]; // wait for write to finish, by reading
 }
-// PAGEBREAK!
 
 void lapicinit(void) {
-  if (!lapic)
+  if(!lapic)
     return;
 
   // Enable local APIC; set spurious interrupt vector.
@@ -69,7 +68,7 @@ void lapicinit(void) {
 
   // Disable performance counter overflow interrupts
   // on machines that provide that interrupt entry.
-  if (((lapic[VER] >> 16) & 0xFF) >= 4)
+  if(((lapic[VER] >> 16) & 0xFF) >= 4)
     lapicw(PCINT, MASKED);
 
   // Map error interrupt to IRQ_ERROR.
@@ -85,8 +84,7 @@ void lapicinit(void) {
   // Send an Init Level De-Assert to synchronise arbitration ID's.
   lapicw(ICRHI, 0);
   lapicw(ICRLO, BCAST | INIT | LEVEL);
-  while (lapic[ICRLO] & DELIVS)
-    ;
+  while(lapic[ICRLO] & DELIVS) {}
 
   // Enable interrupts on the APIC (but not on the processor).
   lapicw(TPR, 0);
@@ -98,21 +96,21 @@ int cpunum(void) {
   // Would prefer to panic but even printing is chancy here:
   // almost everything, including cprintf and panic, calls cpu,
   // often indirectly through acquire and release.
-  if (readeflags() & FL_IF) {
+  if(readeflags() & FL_IF) {
     static int n;
-    if (n++ == 0)
+    if(n++ == 0)
       cprintf("cpu called from %x with interrupts enabled\n",
-              __builtin_return_address(0));
+          __builtin_return_address(0));
   }
 
-  if (lapic)
+  if(lapic)
     return lapic[ID] >> 24;
   return 0;
 }
 
 // Acknowledge interrupt.
 void lapiceoi(void) {
-  if (lapic)
+  if(lapic)
     lapicw(EOI, 0);
 }
 
@@ -127,14 +125,14 @@ void microdelay(int us) {}
 // See Appendix B of MultiProcessor Specification.
 void lapicstartap(uchar apicid, uint addr) {
   int i;
-  ushort *wrv;
+  ushort* wrv;
 
   // "The BSP must initialize CMOS shutdown code to 0AH
   // and the warm reset vector (DWORD based at 40:67) to point at
   // the AP startup code prior to the [universal startup algorithm]."
   outb(CMOS_PORT, 0xF); // offset 0xF is shutdown code
   outb(CMOS_PORT + 1, 0x0A);
-  wrv = (ushort *)P2V((0x40 << 4 | 0x67)); // Warm reset vector
+  wrv = (ushort*) P2V((0x40 << 4 | 0x67)); // Warm reset vector
   wrv[0] = 0;
   wrv[1] = addr >> 4;
 
@@ -151,7 +149,7 @@ void lapicstartap(uchar apicid, uint addr) {
   // when it is in the halted state due to an INIT.  So the second
   // should be ignored, but it is part of the official Intel algorithm.
   // Bochs complains about the second one.  Too bad for Bochs.
-  for (i = 0; i < 2; i++) {
+  for(i = 0; i < 2; i++) {
     lapicw(ICRHI, apicid << 24);
     lapicw(ICRLO, STARTUP | (addr >> 12));
     microdelay(200);
@@ -176,7 +174,7 @@ static uint cmos_read(uint reg) {
   return inb(CMOS_RETURN);
 }
 
-static void fill_rtcdate(struct rtcdate *r) {
+static void fill_rtcdate(struct rtcdate* r) {
   r->second = cmos_read(SECS);
   r->minute = cmos_read(MINS);
   r->hour = cmos_read(HOURS);
@@ -186,7 +184,7 @@ static void fill_rtcdate(struct rtcdate *r) {
 }
 
 // qemu seems to use 24-hour GWT and the values are BCD encoded
-void cmostime(struct rtcdate *r) {
+void cmostime(struct rtcdate* r) {
   struct rtcdate t1, t2;
   int sb, bcd;
 
@@ -195,17 +193,17 @@ void cmostime(struct rtcdate *r) {
   bcd = (sb & (1 << 2)) == 0;
 
   // make sure CMOS doesn't modify time while we read it
-  for (;;) {
+  for(;;) {
     fill_rtcdate(&t1);
-    if (cmos_read(CMOS_STATA) & CMOS_UIP)
+    if(cmos_read(CMOS_STATA) & CMOS_UIP)
       continue;
     fill_rtcdate(&t2);
-    if (memcmp(&t1, &t2, sizeof(t1)) == 0)
+    if(memcmp(&t1, &t2, sizeof(t1)) == 0)
       break;
   }
 
   // convert
-  if (bcd) {
+  if(bcd) {
 #define CONV(x) (t1.x = ((t1.x >> 4) * 10) + (t1.x & 0xf))
     CONV(second);
     CONV(minute);

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -1,14 +1,14 @@
-#include "kernel/types.h"
 #include "kernel/defs.h"
-#include "kernel/param.h"
 #include "kernel/memlayout.h"
 #include "kernel/mmu.h"
+#include "kernel/param.h"
 #include "kernel/proc.h"
+#include "kernel/types.h"
 #include "kernel/x86.h"
 
 static void startothers(void);
 static void mpmain(void) __attribute__((noreturn));
-extern pde_t *kpgdir;
+extern pde_t* kpgdir;
 extern char end[]; // first address after kernel loaded from ELF file
 
 // Bootstrap processor starts running C code here.
@@ -30,7 +30,7 @@ int main(void) {
   binit();       // buffer cache
   fileinit();    // file table
   ideinit();     // disk
-  if (!ismp)
+  if(!ismp)
     timerinit();                              // uniprocessor timer
   startothers();                              // start other processors
   kinit2(P2V(4 * 1024 * 1024), P2V(PHYSTOP)); // must come after startothers()
@@ -59,34 +59,35 @@ pde_t entrypgdir[]; // For entry.S
 
 // Start the non-boot (AP) processors.
 static void startothers(void) {
-  extern uchar _binary_kernel_entryother_start[], _binary_kernel_entryother_size[];
-  uchar *code;
-  struct cpu *c;
-  char *stack;
+  extern uchar _binary_kernel_entryother_start[],
+      _binary_kernel_entryother_size[];
+  uchar* code;
+  struct cpu* c;
+  char* stack;
 
   // Write entry code to unused memory at 0x7000.
   // The linker has placed the image of entryother.S in
   // _binary_entryother_start.
   code = p2v(0x7000);
-  memmove(code, _binary_kernel_entryother_start, (uint)_binary_kernel_entryother_size);
+  memmove(code, _binary_kernel_entryother_start,
+      (uint) _binary_kernel_entryother_size);
 
-  for (c = cpus; c < cpus + ncpu; c++) {
-    if (c == cpus + cpunum()) // We've started already.
+  for(c = cpus; c < cpus + ncpu; c++) {
+    if(c == cpus + cpunum()) // We've started already.
       continue;
 
     // Tell entryother.S what stack to use, where to enter, and what
     // pgdir to use. We cannot use kpgdir yet, because the AP processor
     // is running in low  memory, so we use entrypgdir for the APs too.
     stack = kalloc();
-    *(void **)(code - 4) = stack + KSTACKSIZE;
-    *(void **)(code - 8) = mpenter;
-    *(int **)(code - 12) = (void *)v2p(entrypgdir);
+    *(void**) (code - 4) = stack + KSTACKSIZE;
+    *(void**) (code - 8) = mpenter;
+    *(int**) (code - 12) = (void*) v2p(entrypgdir);
 
     lapicstartap(c->id, v2p(code));
 
     // wait for cpu to finish mpmain()
-    while (c->started == 0)
-      ;
+    while(c->started == 0) {}
   }
 }
 
@@ -100,10 +101,3 @@ __attribute__((__aligned__(PGSIZE))) pde_t entrypgdir[NPDENTRIES] = {
     // Map VA's [KERNBASE, KERNBASE+4MB) to PA's [0, 4MB)
     [KERNBASE >> PDXSHIFT] = (0) | PTE_P | PTE_W | PTE_PS,
 };
-
-// PAGEBREAK!
-// Blank page.
-// PAGEBREAK!
-// Blank page.
-// PAGEBREAK!
-// Blank page.

--- a/kernel/memlayout.h
+++ b/kernel/memlayout.h
@@ -1,22 +1,32 @@
+#ifndef XV6_MEMLAYOUT_H
+#define XV6_MEMLAYOUT_H
+
 // Memory layout
 
-#define EXTMEM  0x100000            // Start of extended memory
-#define PHYSTOP 0xE000000           // Top physical memory
-#define DEVSPACE 0xFE000000         // Other devices are at high addresses
+#define EXTMEM 0x100000     // Start of extended memory
+#define PHYSTOP 0xE000000   // Top physical memory
+#define DEVSPACE 0xFE000000 // Other devices are at high addresses
 
 // Key addresses for address space layout (see kmap in vm.c for layout)
-#define KERNBASE 0x80000000         // First kernel virtual address
-#define KERNLINK (KERNBASE+EXTMEM)  // Address where kernel is linked
+#define KERNBASE 0x80000000          // First kernel virtual address
+#define KERNLINK (KERNBASE + EXTMEM) // Address where kernel is linked
 
 #ifndef __ASSEMBLER__
+#include "kernel/types.h"
 
-static inline uint v2p(void *a) { return ((uint) (a))  - KERNBASE; }
-static inline void *p2v(uint a) { return (void *) ((a) + KERNBASE); }
+static inline uint v2p(void* a) {
+  return ((uint) (a)) - KERNBASE;
+}
+static inline void* p2v(uint a) {
+  return (void*) ((a) + KERNBASE);
+}
 
 #endif
 
 #define V2P(a) (((uint) (a)) - KERNBASE)
-#define P2V(a) (((void *) (a)) + KERNBASE)
+#define P2V(a) (((void*) (a)) + KERNBASE)
 
-#define V2P_WO(x) ((x) - KERNBASE)    // same as V2P, but without casts
-#define P2V_WO(x) ((x) + KERNBASE)    // same as P2V, but without casts
+#define V2P_WO(x) ((x) -KERNBASE)  // same as V2P, but without casts
+#define P2V_WO(x) ((x) + KERNBASE) // same as P2V, but without casts
+
+#endif // XV6_MEMLAYOUT_H

--- a/kernel/mmu.h
+++ b/kernel/mmu.h
@@ -49,7 +49,6 @@
 #define SEG_UDATA 5 // user data+stack
 #define SEG_TSS 6   // this process's task state
 
-// PAGEBREAK!
 #ifndef __ASSEMBLER__
 // Segment Descriptor
 struct segdesc {
@@ -71,13 +70,14 @@ struct segdesc {
 // Normal segment
 #define SEG(type, base, lim, dpl)                                              \
   (struct segdesc) {                                                           \
-    ((lim) >> 12) & 0xffff, (uint)(base)&0xffff, ((uint)(base) >> 16) & 0xff,  \
-        type, 1, dpl, 1, (uint)(lim) >> 28, 0, 0, 1, 1, (uint)(base) >> 24     \
+    ((lim) >> 12) & 0xffff, (uint) (base) &0xffff,                             \
+        ((uint) (base) >> 16) & 0xff, type, 1, dpl, 1, (uint) (lim) >> 28, 0,  \
+        0, 1, 1, (uint) (base) >> 24                                           \
   }
 #define SEG16(type, base, lim, dpl)                                            \
   (struct segdesc) {                                                           \
-    (lim) & 0xffff, (uint)(base)&0xffff, ((uint)(base) >> 16) & 0xff, type, 1, \
-        dpl, 1, (uint)(lim) >> 16, 0, 0, 1, 0, (uint)(base) >> 24              \
+    (lim) & 0xffff, (uint) (base) &0xffff, ((uint) (base) >> 16) & 0xff, type, \
+        1, dpl, 1, (uint) (lim) >> 16, 0, 0, 1, 0, (uint) (base) >> 24         \
   }
 #endif
 
@@ -114,13 +114,13 @@ struct segdesc {
 //  \--- PDX(va) --/ \--- PTX(va) --/
 
 // page directory index
-#define PDX(va) (((uint)(va) >> PDXSHIFT) & 0x3FF)
+#define PDX(va) (((uint) (va) >> PDXSHIFT) & 0x3FF)
 
 // page table index
-#define PTX(va) (((uint)(va) >> PTXSHIFT) & 0x3FF)
+#define PTX(va) (((uint) (va) >> PTXSHIFT) & 0x3FF)
 
 // construct virtual address from indexes and offset
-#define PGADDR(d, t, o) ((uint)((d) << PDXSHIFT | (t) << PTXSHIFT | (o)))
+#define PGADDR(d, t, o) ((uint) ((d) << PDXSHIFT | (t) << PTXSHIFT | (o)))
 
 // Page directory and page table constants.
 #define NPDENTRIES 1024 // # directory entries per page directory
@@ -146,8 +146,8 @@ struct segdesc {
 #define PTE_MBZ 0x180 // Bits must be zero
 
 // Address in page table or page directory entry
-#define PTE_ADDR(pte) ((uint)(pte) & ~0xFFF)
-#define PTE_FLAGS(pte) ((uint)(pte)&0xFFF)
+#define PTE_ADDR(pte) ((uint) (pte) & ~0xFFF)
+#define PTE_FLAGS(pte) ((uint) (pte) &0xFFF)
 
 #ifndef __ASSEMBLER__
 #include "types.h"
@@ -160,21 +160,21 @@ struct taskstate {
   uint esp0;  // Stack pointers and segment selectors
   ushort ss0; //   after an increase in privilege level
   ushort padding1;
-  uint *esp1;
+  uint* esp1;
   ushort ss1;
   ushort padding2;
-  uint *esp2;
+  uint* esp2;
   ushort ss2;
   ushort padding3;
-  void *cr3; // Page directory base
-  uint *eip; // Saved state from last task switch
+  void* cr3; // Page directory base
+  uint* eip; // Saved state from last task switch
   uint eflags;
   uint eax; // More saved state (registers)
   uint ecx;
   uint edx;
   uint ebx;
-  uint *esp;
-  uint *ebp;
+  uint* esp;
+  uint* ebp;
   uint esi;
   uint edi;
   ushort es; // Even more saved state (segment selectors)
@@ -195,7 +195,6 @@ struct taskstate {
   ushort iomb; // I/O map base address
 };
 
-// PAGEBREAK: 12
 // Gate descriptors for interrupts and traps
 struct gatedesc {
   uint off_15_0 : 16;  // low 16 bits of offset in segment
@@ -219,7 +218,7 @@ struct gatedesc {
 //        this interrupt/trap gate explicitly using an int instruction.
 #define SETGATE(gate, istrap, sel, off, d)                                     \
   {                                                                            \
-    (gate).off_15_0 = (uint)(off)&0xffff;                                      \
+    (gate).off_15_0 = (uint) (off) &0xffff;                                    \
     (gate).cs = (sel);                                                         \
     (gate).args = 0;                                                           \
     (gate).rsv1 = 0;                                                           \
@@ -227,7 +226,7 @@ struct gatedesc {
     (gate).s = 0;                                                              \
     (gate).dpl = (d);                                                          \
     (gate).p = 1;                                                              \
-    (gate).off_31_16 = (uint)(off) >> 16;                                      \
+    (gate).off_31_16 = (uint) (off) >> 16;                                     \
   }
 
 #endif

--- a/kernel/mp.c
+++ b/kernel/mp.c
@@ -2,41 +2,43 @@
 // Search memory for MP description structures.
 // http://developer.intel.com/design/pentium/datashts/24201606.pdf
 
-#include "kernel/types.h"
-#include "kernel/defs.h"
-#include "kernel/param.h"
-#include "kernel/memlayout.h"
 #include "kernel/mp.h"
-#include "kernel/x86.h"
+#include "kernel/defs.h"
+#include "kernel/memlayout.h"
 #include "kernel/mmu.h"
+#include "kernel/param.h"
 #include "kernel/proc.h"
+#include "kernel/types.h"
+#include "kernel/x86.h"
 
 struct cpu cpus[NCPU];
-static struct cpu *bcpu;
+static struct cpu* bcpu;
 int ismp;
 int ncpu;
 uchar ioapicid;
 
-int mpbcpu(void) { return bcpu - cpus; }
+int mpbcpu(void) {
+  return bcpu - cpus;
+}
 
-static uchar sum(uchar *addr, int len) {
+static uchar sum(uchar* addr, int len) {
   int i, sum;
 
   sum = 0;
-  for (i = 0; i < len; i++)
+  for(i = 0; i < len; i++)
     sum += addr[i];
   return sum;
 }
 
 // Look for an MP structure in the len bytes at addr.
-static struct mp *mpsearch1(uint a, int len) {
+static struct mp* mpsearch1(uint a, int len) {
   uchar *e, *p, *addr;
 
   addr = p2v(a);
   e = addr + len;
-  for (p = addr; p < e; p += sizeof(struct mp))
-    if (memcmp(p, "_MP_", 4) == 0 && sum(p, sizeof(struct mp)) == 0)
-      return (struct mp *)p;
+  for(p = addr; p < e; p += sizeof(struct mp))
+    if(memcmp(p, "_MP_", 4) == 0 && sum(p, sizeof(struct mp)) == 0)
+      return (struct mp*) p;
   return 0;
 }
 
@@ -45,18 +47,18 @@ static struct mp *mpsearch1(uint a, int len) {
 // 1) in the first KB of the EBDA;
 // 2) in the last KB of system base memory;
 // 3) in the BIOS ROM between 0xE0000 and 0xFFFFF.
-static struct mp *mpsearch(void) {
-  uchar *bda;
+static struct mp* mpsearch(void) {
+  uchar* bda;
   uint p;
-  struct mp *mp;
+  struct mp* mp;
 
-  bda = (uchar *)P2V(0x400);
-  if ((p = ((bda[0x0F] << 8) | bda[0x0E]) << 4)) {
-    if ((mp = mpsearch1(p, 1024)))
+  bda = (uchar*) P2V(0x400);
+  if((p = ((bda[0x0F] << 8) | bda[0x0E]) << 4)) {
+    if((mp = mpsearch1(p, 1024)))
       return mp;
   } else {
     p = ((bda[0x14] << 8) | bda[0x13]) * 1024;
-    if ((mp = mpsearch1(p - 1024, 1024)))
+    if((mp = mpsearch1(p - 1024, 1024)))
       return mp;
   }
   return mpsearch1(0xF0000, 0x10000);
@@ -67,18 +69,18 @@ static struct mp *mpsearch(void) {
 // Check for correct signature, calculate the checksum and,
 // if correct, check the version.
 // To do: check extended table checksum.
-static struct mpconf *mpconfig(struct mp **pmp) {
-  struct mpconf *conf;
-  struct mp *mp;
+static struct mpconf* mpconfig(struct mp** pmp) {
+  struct mpconf* conf;
+  struct mp* mp;
 
-  if ((mp = mpsearch()) == 0 || mp->physaddr == 0)
+  if((mp = mpsearch()) == 0 || mp->physaddr == 0)
     return 0;
-  conf = (struct mpconf *)p2v((uint)mp->physaddr);
-  if (memcmp(conf, "PCMP", 4) != 0)
+  conf = (struct mpconf*) p2v((uint) mp->physaddr);
+  if(memcmp(conf, "PCMP", 4) != 0)
     return 0;
-  if (conf->version != 1 && conf->version != 4)
+  if(conf->version != 1 && conf->version != 4)
     return 0;
-  if (sum((uchar *)conf, conf->length) != 0)
+  if(sum((uchar*) conf, conf->length) != 0)
     return 0;
   *pmp = mp;
   return conf;
@@ -86,46 +88,46 @@ static struct mpconf *mpconfig(struct mp **pmp) {
 
 void mpinit(void) {
   uchar *p, *e;
-  struct mp *mp;
-  struct mpconf *conf;
-  struct mpproc *proc;
-  struct mpioapic *ioapic;
+  struct mp* mp;
+  struct mpconf* conf;
+  struct mpproc* proc;
+  struct mpioapic* ioapic;
 
   bcpu = &cpus[0];
-  if ((conf = mpconfig(&mp)) == 0)
+  if((conf = mpconfig(&mp)) == 0)
     return;
   ismp = 1;
-  lapic = (uint *)conf->lapicaddr;
-  for (p = (uchar *)(conf + 1), e = (uchar *)conf + conf->length; p < e;) {
-    switch (*p) {
-    case MPPROC:
-      proc = (struct mpproc *)p;
-      if (ncpu != proc->apicid) {
-        cprintf("mpinit: ncpu=%d apicid=%d\n", ncpu, proc->apicid);
+  lapic = (uint*) conf->lapicaddr;
+  for(p = (uchar*) (conf + 1), e = (uchar*) conf + conf->length; p < e;) {
+    switch(*p) {
+      case MPPROC:
+        proc = (struct mpproc*) p;
+        if(ncpu != proc->apicid) {
+          cprintf("mpinit: ncpu=%d apicid=%d\n", ncpu, proc->apicid);
+          ismp = 0;
+        }
+        if(proc->flags & MPBOOT)
+          bcpu = &cpus[ncpu];
+        cpus[ncpu].id = ncpu;
+        ncpu++;
+        p += sizeof(struct mpproc);
+        continue;
+      case MPIOAPIC:
+        ioapic = (struct mpioapic*) p;
+        ioapicid = ioapic->apicno;
+        p += sizeof(struct mpioapic);
+        continue;
+      case MPBUS:
+      case MPIOINTR:
+      case MPLINTR:
+        p += 8;
+        continue;
+      default:
+        cprintf("mpinit: unknown config type %x\n", *p);
         ismp = 0;
-      }
-      if (proc->flags & MPBOOT)
-        bcpu = &cpus[ncpu];
-      cpus[ncpu].id = ncpu;
-      ncpu++;
-      p += sizeof(struct mpproc);
-      continue;
-    case MPIOAPIC:
-      ioapic = (struct mpioapic *)p;
-      ioapicid = ioapic->apicno;
-      p += sizeof(struct mpioapic);
-      continue;
-    case MPBUS:
-    case MPIOINTR:
-    case MPLINTR:
-      p += 8;
-      continue;
-    default:
-      cprintf("mpinit: unknown config type %x\n", *p);
-      ismp = 0;
     }
   }
-  if (!ismp) {
+  if(!ismp) {
     // Didn't like what we found; fall back to no MP.
     ncpu = 1;
     lapic = 0;
@@ -133,7 +135,7 @@ void mpinit(void) {
     return;
   }
 
-  if (mp->imcrp) {
+  if(mp->imcrp) {
     // Bochs doesn't support IMCR, so this doesn't run on Bochs.
     // But it would on real hardware.
     outb(0x22, 0x70);          // Select IMCR

--- a/kernel/mp.h
+++ b/kernel/mp.h
@@ -7,7 +7,7 @@
 
 struct mp {           // floating pointer
   uchar signature[4]; // "_MP_"
-  void *physaddr;     // phys addr of MP config table
+  void* physaddr;     // phys addr of MP config table
   uchar length;       // 1
   uchar specrev;      // [14]
   uchar checksum;     // all bytes must add up to 0
@@ -22,10 +22,10 @@ struct mpconf {       // configuration table header
   uchar version;      // [14]
   uchar checksum;     // all bytes must add up to 0
   uchar product[20];  // product id
-  uint *oemtable;     // OEM table pointer
+  uint* oemtable;     // OEM table pointer
   ushort oemlength;   // OEM table length
   ushort entry;       // entry count
-  uint *lapicaddr;    // address of local APIC
+  uint* lapicaddr;    // address of local APIC
   ushort xlength;     // extended table length
   uchar xchecksum;    // extended table checksum
   uchar reserved;
@@ -47,7 +47,7 @@ struct mpioapic { // I/O APIC table entry
   uchar apicno;   // I/O APIC id
   uchar version;  // I/O APIC version
   uchar flags;    // I/O APIC flags
-  uint *addr;     // I/O APIC address
+  uint* addr;     // I/O APIC address
 };
 
 // Table entry types
@@ -56,8 +56,5 @@ struct mpioapic { // I/O APIC table entry
 #define MPIOAPIC 0x02 // One per I/O APIC
 #define MPIOINTR 0x03 // One per bus interrupt source
 #define MPLINTR 0x04  // One per system interrupt source
-
-// PAGEBREAK!
-//  Blank page.
 
 #endif // XV6_MP_H

--- a/kernel/picirq.c
+++ b/kernel/picirq.c
@@ -1,8 +1,8 @@
 // Intel 8259A programmable interrupt controllers.
 
+#include "kernel/traps.h"
 #include "kernel/types.h"
 #include "kernel/x86.h"
-#include "kernel/traps.h"
 
 // I/O Addresses of the two programmable interrupt controllers
 #define IO_PIC1 0x20 // Master (IRQs 0-7)
@@ -20,7 +20,9 @@ static void picsetmask(ushort mask) {
   outb(IO_PIC2 + 1, mask >> 8);
 }
 
-void picenable(int irq) { picsetmask(irqmask & ~(1 << irq)); }
+void picenable(int irq) {
+  picsetmask(irqmask & ~(1 << irq));
+}
 
 // Initialize the 8259A interrupt controllers.
 void picinit(void) {
@@ -71,6 +73,6 @@ void picinit(void) {
   outb(IO_PIC2, 0x68); // OCW3
   outb(IO_PIC2, 0x0a); // OCW3
 
-  if (irqmask != 0xFFFF)
+  if(irqmask != 0xFFFF)
     picsetmask(irqmask);
 }

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -1,36 +1,37 @@
-#include "kernel/types.h"
+#include "kernel/proc.h"
 #include "kernel/defs.h"
-#include "kernel/param.h"
 #include "kernel/memlayout.h"
 #include "kernel/mmu.h"
-#include "kernel/x86.h"
-#include "kernel/proc.h"
+#include "kernel/param.h"
 #include "kernel/spinlock.h"
+#include "kernel/types.h"
+#include "kernel/x86.h"
 
 struct ptable ptable;
 
-static struct proc *initproc;
+static struct proc* initproc;
 
 int nextpid = 1;
 extern void forkret(void);
 extern void trapret(void);
 
-static void wakeup1(void *chan);
+static void wakeup1(void* chan);
 
-void pinit(void) { initlock(&ptable.lock, "ptable"); }
+void pinit(void) {
+  initlock(&ptable.lock, "ptable");
+}
 
-// PAGEBREAK: 32
 // Look in the process table for an UNUSED proc.
 // If found, change state to EMBRYO and initialize
 // state required to run in the kernel.
 // Otherwise return 0.
-static struct proc *allocproc(void) {
-  struct proc *p;
-  char *sp;
+static struct proc* allocproc(void) {
+  struct proc* p;
+  char* sp;
 
   acquire(&ptable.lock);
-  for (p = ptable.proc; p < &ptable.proc[NPROC]; p++)
-    if (p->state == UNUSED)
+  for(p = ptable.proc; p < &ptable.proc[NPROC]; p++)
+    if(p->state == UNUSED)
       goto found;
   release(&ptable.lock);
   return 0;
@@ -41,7 +42,7 @@ found:
   release(&ptable.lock);
 
   // Allocate kernel stack.
-  if ((p->kstack = kalloc()) == 0) {
+  if((p->kstack = kalloc()) == 0) {
     p->state = UNUSED;
     return 0;
   }
@@ -49,33 +50,32 @@ found:
 
   // Leave room for trap frame.
   sp -= sizeof *p->tf;
-  p->tf = (struct trapframe *)sp;
+  p->tf = (struct trapframe*) sp;
 
   // Set up new context to start executing at forkret,
   // which returns to trapret.
   sp -= 4;
-  *(uint *)sp = (uint)trapret;
+  *(uint*) sp = (uint) trapret;
 
   sp -= sizeof *p->context;
-  p->context = (struct context *)sp;
+  p->context = (struct context*) sp;
   memset(p->context, 0, sizeof *p->context);
-  p->context->eip = (uint)forkret;
+  p->context->eip = (uint) forkret;
 
   return p;
 }
 
-// PAGEBREAK: 32
 // Set up first user process.
 void userinit(void) {
-  struct proc *p;
+  struct proc* p;
   extern char _binary_user_initcode_start[], _binary_user_initcode_size[];
 
   p = allocproc();
   initproc = p;
-  if ((p->pgdir = setupkvm()) == 0)
+  if((p->pgdir = setupkvm()) == 0)
     panic("userinit: out of memory?");
   inituvm(p->pgdir, _binary_user_initcode_start,
-          (int)_binary_user_initcode_size);
+      (int) _binary_user_initcode_size);
   p->sz = PGSIZE;
   memset(p->tf, 0, sizeof(*p->tf));
   p->tf->cs = (SEG_UCODE << 3) | DPL_USER;
@@ -98,11 +98,11 @@ int growproc(int n) {
   uint sz;
 
   sz = proc->sz;
-  if (n > 0) {
-    if ((sz = allocuvm(proc->pgdir, sz, sz + n)) == 0)
+  if(n > 0) {
+    if((sz = allocuvm(proc->pgdir, sz, sz + n)) == 0)
       return -1;
-  } else if (n < 0) {
-    if ((sz = deallocuvm(proc->pgdir, sz, sz + n)) == 0)
+  } else if(n < 0) {
+    if((sz = deallocuvm(proc->pgdir, sz, sz + n)) == 0)
       return -1;
   }
   proc->sz = sz;
@@ -115,14 +115,14 @@ int growproc(int n) {
 // Caller must set state of returned proc to RUNNABLE.
 int fork(void) {
   int i, pid;
-  struct proc *np;
+  struct proc* np;
 
   // Allocate process.
-  if ((np = allocproc()) == 0)
+  if((np = allocproc()) == 0)
     return -1;
 
   // Copy process state from p.
-  if ((np->pgdir = copyuvm(proc->pgdir, proc->sz)) == 0) {
+  if((np->pgdir = copyuvm(proc->pgdir, proc->sz)) == 0) {
     kfree(np->kstack);
     np->kstack = 0;
     np->state = UNUSED;
@@ -135,8 +135,8 @@ int fork(void) {
   // Clear %eax so that fork returns 0 in the child.
   np->tf->eax = 0;
 
-  for (i = 0; i < NOFILE; i++)
-    if (proc->ofile[i])
+  for(i = 0; i < NOFILE; i++)
+    if(proc->ofile[i])
       np->ofile[i] = filedup(proc->ofile[i]);
   np->cwd = idup(proc->cwd);
 
@@ -156,15 +156,15 @@ int fork(void) {
 // An exited process remains in the zombie state
 // until its parent calls wait() to find out it exited.
 void exit(void) {
-  struct proc *p;
+  struct proc* p;
   int fd;
 
-  if (proc == initproc)
+  if(proc == initproc)
     panic("init exiting");
 
   // Close all open files.
-  for (fd = 0; fd < NOFILE; fd++) {
-    if (proc->ofile[fd]) {
+  for(fd = 0; fd < NOFILE; fd++) {
+    if(proc->ofile[fd]) {
       fileclose(proc->ofile[fd]);
       proc->ofile[fd] = 0;
     }
@@ -181,10 +181,10 @@ void exit(void) {
   wakeup1(proc->parent);
 
   // Pass abandoned children to init.
-  for (p = ptable.proc; p < &ptable.proc[NPROC]; p++) {
-    if (p->parent == proc) {
+  for(p = ptable.proc; p < &ptable.proc[NPROC]; p++) {
+    if(p->parent == proc) {
       p->parent = initproc;
-      if (p->state == ZOMBIE)
+      if(p->state == ZOMBIE)
         wakeup1(initproc);
     }
   }
@@ -198,18 +198,18 @@ void exit(void) {
 // Wait for a child process to exit and return its pid.
 // Return -1 if this process has no children.
 int wait(void) {
-  struct proc *p;
+  struct proc* p;
   int havekids, pid;
 
   acquire(&ptable.lock);
-  for (;;) {
+  for(;;) {
     // Scan through table looking for zombie children.
     havekids = 0;
-    for (p = ptable.proc; p < &ptable.proc[NPROC]; p++) {
-      if (p->parent != proc)
+    for(p = ptable.proc; p < &ptable.proc[NPROC]; p++) {
+      if(p->parent != proc)
         continue;
       havekids = 1;
-      if (p->state == ZOMBIE) {
+      if(p->state == ZOMBIE) {
         // Found one.
         pid = p->pid;
         kfree(p->kstack);
@@ -226,7 +226,7 @@ int wait(void) {
     }
 
     // No point waiting if we don't have any children.
-    if (!havekids || proc->killed) {
+    if(!havekids || proc->killed) {
       release(&ptable.lock);
       return -1;
     }
@@ -236,7 +236,6 @@ int wait(void) {
   }
 }
 
-// PAGEBREAK: 42
 // Per-CPU process scheduler.
 // Each CPU calls scheduler() after setting itself up.
 // Scheduler never returns.  It loops, doing:
@@ -245,22 +244,22 @@ int wait(void) {
 //  - eventually that process transfers control
 //      via swtch back to the scheduler.
 void scheduler(void) {
-  struct proc *p;
+  struct proc* p;
   int foundproc = 1;
 
-  for (;;) {
+  for(;;) {
     // Enable interrupts on this processor.
     sti();
 
-    if (!foundproc)
+    if(!foundproc)
       hlt();
 
     foundproc = 0;
 
     // Loop over process table looking for process to run.
     acquire(&ptable.lock);
-    for (p = ptable.proc; p < &ptable.proc[NPROC]; p++) {
-      if (p->state != RUNNABLE)
+    for(p = ptable.proc; p < &ptable.proc[NPROC]; p++) {
+      if(p->state != RUNNABLE)
         continue;
 
       // Switch to chosen process.  It is the process's job
@@ -286,13 +285,13 @@ void scheduler(void) {
 void sched(void) {
   int intena;
 
-  if (!holding(&ptable.lock))
+  if(!holding(&ptable.lock))
     panic("sched ptable.lock");
-  if (cpu->ncli != 1)
+  if(cpu->ncli != 1)
     panic("sched locks");
-  if (proc->state == RUNNING)
+  if(proc->state == RUNNING)
     panic("sched running");
-  if (readeflags() & FL_IF)
+  if(readeflags() & FL_IF)
     panic("sched interruptible");
   intena = cpu->intena;
   swtch(&proc->context, cpu->scheduler);
@@ -314,7 +313,7 @@ void forkret(void) {
   // Still holding ptable.lock from scheduler.
   release(&ptable.lock);
 
-  if (first) {
+  if(first) {
     // Some initialization functions must be run in the context
     // of a regular process (e.g., they call sleep), and thus cannot
     // be run from main().
@@ -328,11 +327,11 @@ void forkret(void) {
 
 // Atomically release lock and sleep on chan.
 // Reacquires lock when awakened.
-void sleep(void *chan, struct spinlock *lk) {
-  if (proc == 0)
+void sleep(void* chan, struct spinlock* lk) {
+  if(proc == 0)
     panic("sleep");
 
-  if (lk == 0)
+  if(lk == 0)
     panic("sleep without lk");
 
   // Must acquire ptable.lock in order to
@@ -341,8 +340,8 @@ void sleep(void *chan, struct spinlock *lk) {
   // guaranteed that we won't miss any wakeup
   // (wakeup runs with ptable.lock locked),
   // so it's okay to release lk.
-  if (lk != &ptable.lock) { // DOC: sleeplock0
-    acquire(&ptable.lock);  // DOC: sleeplock1
+  if(lk != &ptable.lock) { // DOC: sleeplock0
+    acquire(&ptable.lock); // DOC: sleeplock1
     release(lk);
   }
 
@@ -355,25 +354,24 @@ void sleep(void *chan, struct spinlock *lk) {
   proc->chan = 0;
 
   // Reacquire original lock.
-  if (lk != &ptable.lock) { // DOC: sleeplock2
+  if(lk != &ptable.lock) { // DOC: sleeplock2
     release(&ptable.lock);
     acquire(lk);
   }
 }
 
-// PAGEBREAK!
 // Wake up all processes sleeping on chan.
 // The ptable lock must be held.
-static void wakeup1(void *chan) {
-  struct proc *p;
+static void wakeup1(void* chan) {
+  struct proc* p;
 
-  for (p = ptable.proc; p < &ptable.proc[NPROC]; p++)
-    if (p->state == SLEEPING && p->chan == chan)
+  for(p = ptable.proc; p < &ptable.proc[NPROC]; p++)
+    if(p->state == SLEEPING && p->chan == chan)
       p->state = RUNNABLE;
 }
 
 // Wake up all processes sleeping on chan.
-void wakeup(void *chan) {
+void wakeup(void* chan) {
   acquire(&ptable.lock);
   wakeup1(chan);
   release(&ptable.lock);
@@ -383,14 +381,14 @@ void wakeup(void *chan) {
 // Process won't exit until it returns
 // to user space (see trap in trap.c).
 int kill(int pid) {
-  struct proc *p;
+  struct proc* p;
 
   acquire(&ptable.lock);
-  for (p = ptable.proc; p < &ptable.proc[NPROC]; p++) {
-    if (p->pid == pid) {
+  for(p = ptable.proc; p < &ptable.proc[NPROC]; p++) {
+    if(p->pid == pid) {
       p->killed = 1;
       // Wake process from sleep if necessary.
-      if (p->state == SLEEPING)
+      if(p->state == SLEEPING)
         p->state = RUNNABLE;
       release(&ptable.lock);
       return 0;
@@ -400,30 +398,32 @@ int kill(int pid) {
   return -1;
 }
 
-// PAGEBREAK: 36
 // Print a process listing to console.  For debugging.
 // Runs when user types ^P on console.
 // No lock to avoid wedging a stuck machine further.
 void procdump(void) {
-  static char *states[] = {
-      [UNUSED] "unused",   [EMBRYO] "embryo",  [SLEEPING] "sleep ",
-      [RUNNABLE] "runble", [RUNNING] "run   ", [ZOMBIE] "zombie"};
+  static char* states[] = {[UNUSED] "unused",
+      [EMBRYO] "embryo",
+      [SLEEPING] "sleep ",
+      [RUNNABLE] "runble",
+      [RUNNING] "run   ",
+      [ZOMBIE] "zombie"};
   int i;
-  struct proc *p;
-  char *state;
+  struct proc* p;
+  char* state;
   uint pc[10];
 
-  for (p = ptable.proc; p < &ptable.proc[NPROC]; p++) {
-    if (p->state == UNUSED)
+  for(p = ptable.proc; p < &ptable.proc[NPROC]; p++) {
+    if(p->state == UNUSED)
       continue;
-    if (p->state >= 0 && p->state < NELEM(states) && states[p->state])
+    if(p->state >= 0 && p->state < NELEM(states) && states[p->state])
       state = states[p->state];
     else
       state = "???";
     cprintf("%d %s %s", p->pid, state, p->name);
-    if (p->state == SLEEPING) {
-      getcallerpcs((uint *)p->context->ebp + 2, pc);
-      for (i = 0; i < 10 && pc[i] != 0; i++)
+    if(p->state == SLEEPING) {
+      getcallerpcs((uint*) p->context->ebp + 2, pc);
+      for(i = 0; i < 10 && pc[i] != 0; i++)
         cprintf(" %p", pc[i]);
     }
     cprintf("\n");

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -1,11 +1,11 @@
 #ifndef XV6_PROC_H
 #define XV6_PROC_H
 
-#include "types.h"
-#include "param.h"
 #include "defs.h"
-#include "spinlock.h"
 #include "mmu.h"
+#include "param.h"
+#include "spinlock.h"
+#include "types.h"
 
 // Segments in proc->gdt.
 #define NSEGS 7
@@ -13,7 +13,7 @@
 // Per-CPU state
 struct cpu {
   uchar id;                  // Local APIC ID; index into cpus[] below
-  struct context *scheduler; // swtch() here to enter scheduler
+  struct context* scheduler; // swtch() here to enter scheduler
   struct taskstate ts;       // Used by x86 to find stack for interrupt
   struct segdesc gdt[NSEGS]; // x86 global descriptor table
   volatile uint started;     // Has the CPU started?
@@ -21,8 +21,8 @@ struct cpu {
   int intena;                // Were interrupts enabled before pushcli?
 
   // Cpu-local storage variables; see below
-  struct cpu *cpu;
-  struct proc *proc; // The currently-running process.
+  struct cpu* cpu;
+  struct proc* proc; // The currently-running process.
 };
 
 extern struct cpu cpus[NCPU];
@@ -36,10 +36,9 @@ extern int ncpu;
 // holding those two variables in the local cpu's struct cpu.
 // This is similar to how thread-local variables are implemented
 // in thread libraries such as Linux pthreads.
-extern struct cpu *cpu asm("%gs:0");   // &cpus[cpunum()]
-extern struct proc *proc asm("%gs:4"); // cpus[cpunum()].proc
+extern struct cpu* cpu asm("%gs:0");   // &cpus[cpunum()]
+extern struct proc* proc asm("%gs:4"); // cpus[cpunum()].proc
 
-// PAGEBREAK: 17
 //  Saved registers for kernel context switches.
 //  Don't need to save all the segment registers (%cs, etc),
 //  because they are constant across kernel contexts.
@@ -70,17 +69,17 @@ enum procstate {
 // Per-process state
 struct proc {
   uint sz;                    // Size of process memory (bytes)
-  pde_t *pgdir;               // Page table
-  char *kstack;               // Bottom of kernel stack for this process
+  pde_t* pgdir;               // Page table
+  char* kstack;               // Bottom of kernel stack for this process
   enum procstate state;       // Process state
   int pid;                    // Process ID
-  struct proc *parent;        // Parent process
-  struct trapframe *tf;       // Trap frame for current syscall
-  struct context *context;    // swtch() here to run process
-  void *chan;                 // If non-zero, sleeping on chan
+  struct proc* parent;        // Parent process
+  struct trapframe* tf;       // Trap frame for current syscall
+  struct context* context;    // swtch() here to run process
+  void* chan;                 // If non-zero, sleeping on chan
   int killed;                 // If non-zero, have been killed
-  struct file *ofile[NOFILE]; // Open files
-  struct inode *cwd;          // Current directory
+  struct file* ofile[NOFILE]; // Open files
+  struct inode* cwd;          // Current directory
   char name[16];              // Process name (debugging)
 };
 

--- a/kernel/spinlock.c
+++ b/kernel/spinlock.c
@@ -1,15 +1,15 @@
 // Mutual exclusion spin locks.
 
-#include "kernel/types.h"
+#include "kernel/spinlock.h"
 #include "kernel/defs.h"
-#include "kernel/param.h"
-#include "kernel/x86.h"
 #include "kernel/memlayout.h"
 #include "kernel/mmu.h"
+#include "kernel/param.h"
 #include "kernel/proc.h"
-#include "kernel/spinlock.h"
+#include "kernel/types.h"
+#include "kernel/x86.h"
 
-void initlock(struct spinlock *lk, char *name) {
+void initlock(struct spinlock* lk, char* name) {
   lk->name = name;
   lk->locked = 0;
   lk->cpu = 0;
@@ -19,16 +19,15 @@ void initlock(struct spinlock *lk, char *name) {
 // Loops (spins) until the lock is acquired.
 // Holding a lock for a long time may cause
 // other CPUs to waste time spinning to acquire it.
-void acquire(struct spinlock *lk) {
+void acquire(struct spinlock* lk) {
   pushcli(); // disable interrupts to avoid deadlock.
-  if (holding(lk))
+  if(holding(lk))
     panic("acquire");
 
   // The xchg is atomic.
   // It also serializes, so that reads after acquire are not
   // reordered before it.
-  while (xchg(&lk->locked, 1) != 0)
-    ;
+  while(xchg(&lk->locked, 1) != 0) {}
 
   // Record info about lock acquisition for debugging.
   lk->cpu = cpu;
@@ -36,8 +35,8 @@ void acquire(struct spinlock *lk) {
 }
 
 // Release the lock.
-void release(struct spinlock *lk) {
-  if (!holding(lk))
+void release(struct spinlock* lk) {
+  if(!holding(lk))
     panic("release");
 
   lk->pcs[0] = 0;
@@ -58,23 +57,25 @@ void release(struct spinlock *lk) {
 }
 
 // Record the current call stack in pcs[] by following the %ebp chain.
-void getcallerpcs(void *v, uint pcs[]) {
-  uint *ebp;
+void getcallerpcs(void* v, uint pcs[]) {
+  uint* ebp;
   int i;
 
-  ebp = (uint *)v - 2;
-  for (i = 0; i < 10; i++) {
-    if (ebp == 0 || ebp < (uint *)KERNBASE || ebp == (uint *)0xffffffff)
+  ebp = (uint*) v - 2;
+  for(i = 0; i < 10; i++) {
+    if(ebp == 0 || ebp < (uint*) KERNBASE || ebp == (uint*) 0xffffffff)
       break;
     pcs[i] = ebp[1];      // saved %eip
-    ebp = (uint *)ebp[0]; // saved %ebp
+    ebp = (uint*) ebp[0]; // saved %ebp
   }
-  for (; i < 10; i++)
+  for(; i < 10; i++)
     pcs[i] = 0;
 }
 
 // Check whether this cpu is holding the lock.
-int holding(struct spinlock *lock) { return lock->locked && lock->cpu == cpu; }
+int holding(struct spinlock* lock) {
+  return lock->locked && lock->cpu == cpu;
+}
 
 // Pushcli/popcli are like cli/sti except that they are matched:
 // it takes two popcli to undo two pushcli.  Also, if interrupts
@@ -85,15 +86,15 @@ void pushcli(void) {
 
   eflags = readeflags();
   cli();
-  if (cpu->ncli++ == 0)
+  if(cpu->ncli++ == 0)
     cpu->intena = eflags & FL_IF;
 }
 
 void popcli(void) {
-  if (readeflags() & FL_IF)
+  if(readeflags() & FL_IF)
     panic("popcli - interruptible");
-  if (--cpu->ncli < 0)
+  if(--cpu->ncli < 0)
     panic("popcli");
-  if (cpu->ncli == 0 && cpu->intena)
+  if(cpu->ncli == 0 && cpu->intena)
     sti();
 }

--- a/kernel/spinlock.h
+++ b/kernel/spinlock.h
@@ -1,16 +1,16 @@
 #ifndef XV6_SPINLOCK_H
 #define XV6_SPINLOCK_H
 
-#include "types.h"
 #include "defs.h"
+#include "types.h"
 
 // Mutual exclusion lock.
 struct spinlock {
   uint locked; // Is the lock held?
 
   // For debugging:
-  char *name;      // Name of lock.
-  struct cpu *cpu; // The cpu holding the lock.
+  char* name;      // Name of lock.
+  struct cpu* cpu; // The cpu holding the lock.
   uint pcs[10];    // The call stack (an array of program counters)
                    // that locked the lock.
 };

--- a/kernel/string.c
+++ b/kernel/string.c
@@ -1,8 +1,8 @@
 #include "kernel/types.h"
 #include "kernel/x86.h"
 
-void *memset(void *dst, int c, uint n) {
-  if ((int)dst % 4 == 0 && n % 4 == 0) {
+void* memset(void* dst, int c, uint n) {
+  if((int) dst % 4 == 0 && n % 4 == 0) {
     c &= 0xFF;
     stosl(dst, (c << 24) | (c << 16) | (c << 8) | c, n / 4);
   } else
@@ -10,13 +10,13 @@ void *memset(void *dst, int c, uint n) {
   return dst;
 }
 
-int memcmp(const void *v1, const void *v2, uint n) {
+int memcmp(const void* v1, const void* v2, uint n) {
   const uchar *s1, *s2;
 
   s1 = v1;
   s2 = v2;
-  while (n-- > 0) {
-    if (*s1 != *s2)
+  while(n-- > 0) {
+    if(*s1 != *s2)
       return *s1 - *s2;
     s1++, s2++;
   }
@@ -24,65 +24,62 @@ int memcmp(const void *v1, const void *v2, uint n) {
   return 0;
 }
 
-void *memmove(void *dst, const void *src, uint n) {
-  const char *s;
-  char *d;
+void* memmove(void* dst, const void* src, uint n) {
+  const char* s;
+  char* d;
 
   s = src;
   d = dst;
-  if (s < d && s + n > d) {
+  if(s < d && s + n > d) {
     s += n;
     d += n;
-    while (n-- > 0)
+    while(n-- > 0)
       *--d = *--s;
   } else
-    while (n-- > 0)
+    while(n-- > 0)
       *d++ = *s++;
 
   return dst;
 }
 
 // memcpy exists to placate GCC.  Use memmove.
-void *memcpy(void *dst, const void *src, uint n) {
+void* memcpy(void* dst, const void* src, uint n) {
   return memmove(dst, src, n);
 }
 
-int strncmp(const char *p, const char *q, uint n) {
-  while (n > 0 && *p && *p == *q)
+int strncmp(const char* p, const char* q, uint n) {
+  while(n > 0 && *p && *p == *q)
     n--, p++, q++;
-  if (n == 0)
+  if(n == 0)
     return 0;
-  return (uchar)*p - (uchar)*q;
+  return (uchar) *p - (uchar) *q;
 }
 
-char *strncpy(char *s, const char *t, int n) {
-  char *os;
+char* strncpy(char* s, const char* t, int n) {
+  char* os;
 
   os = s;
-  while (n-- > 0 && (*s++ = *t++) != 0)
-    ;
-  while (n-- > 0)
+  while(n-- > 0 && (*s++ = *t++) != 0) {}
+  while(n-- > 0)
     *s++ = 0;
   return os;
 }
 
 // Like strncpy but guaranteed to NUL-terminate.
-char *safestrcpy(char *s, const char *t, int n) {
-  char *os;
+char* safestrcpy(char* s, const char* t, int n) {
+  char* os;
 
   os = s;
-  if (n <= 0)
+  if(n <= 0)
     return os;
-  while (--n > 0 && (*s++ = *t++) != 0)
-    ;
+  while(--n > 0 && (*s++ = *t++) != 0) {}
   *s = 0;
   return os;
 }
 
-int strlen(const char *s) {
+int strlen(const char* s) {
   int n;
 
-  for (n = 0; s[n]; n++)
-    ;
+  for(n = 0; s[n]; n++) {}
   return n;
 }

--- a/kernel/swtch.S
+++ b/kernel/swtch.S
@@ -1,7 +1,7 @@
 # Context switch
 #
 #   void swtch(struct context **old, struct context *new);
-# 
+#
 # Save current register context in old
 # and then load register context from new.
 

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -1,11 +1,11 @@
-#include "kernel/types.h"
+#include "kernel/syscall.h"
 #include "kernel/defs.h"
-#include "kernel/param.h"
 #include "kernel/memlayout.h"
 #include "kernel/mmu.h"
+#include "kernel/param.h"
 #include "kernel/proc.h"
+#include "kernel/types.h"
 #include "kernel/x86.h"
-#include "kernel/syscall.h"
 
 // User code makes a system call with INT T_SYSCALL.
 // System call number in %eax.
@@ -14,43 +14,45 @@
 // to a saved program counter, and then the first argument.
 
 // Fetch the int at addr from the current process.
-int fetchint(uint addr, int *ip) {
-  if (addr >= proc->sz || addr + 4 > proc->sz)
+int fetchint(uint addr, int* ip) {
+  if(addr >= proc->sz || addr + 4 > proc->sz)
     return -1;
-  *ip = *(int *)(addr);
+  *ip = *(int*) (addr);
   return 0;
 }
 
 // Fetch the nul-terminated string at addr from the current process.
 // Doesn't actually copy the string - just sets *pp to point at it.
 // Returns length of string, not including nul.
-int fetchstr(uint addr, char **pp) {
+int fetchstr(uint addr, char** pp) {
   char *s, *ep;
 
-  if (addr >= proc->sz)
+  if(addr >= proc->sz)
     return -1;
-  *pp = (char *)addr;
-  ep = (char *)proc->sz;
-  for (s = *pp; s < ep; s++)
-    if (*s == 0)
+  *pp = (char*) addr;
+  ep = (char*) proc->sz;
+  for(s = *pp; s < ep; s++)
+    if(*s == 0)
       return s - *pp;
   return -1;
 }
 
 // Fetch the nth 32-bit system call argument.
-int argint(int n, int *ip) { return fetchint(proc->tf->esp + 4 + 4 * n, ip); }
+int argint(int n, int* ip) {
+  return fetchint(proc->tf->esp + 4 + 4 * n, ip);
+}
 
 // Fetch the nth word-sized system call argument as a pointer
 // to a block of memory of size n bytes.  Check that the pointer
 // lies within the process address space.
-int argptr(int n, char **pp, int size) {
+int argptr(int n, char** pp, int size) {
   int i;
 
-  if (argint(n, &i) < 0)
+  if(argint(n, &i) < 0)
     return -1;
-  if ((uint)i >= proc->sz || (uint)i + size > proc->sz)
+  if((uint) i >= proc->sz || (uint) i + size > proc->sz)
     return -1;
-  *pp = (char *)i;
+  *pp = (char*) i;
   return 0;
 }
 
@@ -58,9 +60,9 @@ int argptr(int n, char **pp, int size) {
 // Check that the pointer is valid and the string is nul-terminated.
 // (There is no shared writable memory, so the string can't change
 // between this check and being used by the kernel.)
-int argstr(int n, char **pp) {
+int argstr(int n, char** pp) {
   int addr;
-  if (argint(n, &addr) < 0)
+  if(argint(n, &addr) < 0)
     return -1;
   return fetchstr(addr, pp);
 }
@@ -88,20 +90,34 @@ extern int sys_write(void);
 extern int sys_uptime(void);
 
 static int (*syscalls[])(void) = {
-    [SYS_fork] sys_fork,   [SYS_exit] sys_exit,     [SYS_wait] sys_wait,
-    [SYS_pipe] sys_pipe,   [SYS_read] sys_read,     [SYS_kill] sys_kill,
-    [SYS_exec] sys_exec,   [SYS_fstat] sys_fstat,   [SYS_chdir] sys_chdir,
-    [SYS_dup] sys_dup,     [SYS_getpid] sys_getpid, [SYS_sbrk] sys_sbrk,
-    [SYS_sleep] sys_sleep, [SYS_uptime] sys_uptime, [SYS_open] sys_open,
-    [SYS_write] sys_write, [SYS_mknod] sys_mknod,   [SYS_unlink] sys_unlink,
-    [SYS_link] sys_link,   [SYS_mkdir] sys_mkdir,   [SYS_close] sys_close,
+    [SYS_fork] sys_fork,
+    [SYS_exit] sys_exit,
+    [SYS_wait] sys_wait,
+    [SYS_pipe] sys_pipe,
+    [SYS_read] sys_read,
+    [SYS_kill] sys_kill,
+    [SYS_exec] sys_exec,
+    [SYS_fstat] sys_fstat,
+    [SYS_chdir] sys_chdir,
+    [SYS_dup] sys_dup,
+    [SYS_getpid] sys_getpid,
+    [SYS_sbrk] sys_sbrk,
+    [SYS_sleep] sys_sleep,
+    [SYS_uptime] sys_uptime,
+    [SYS_open] sys_open,
+    [SYS_write] sys_write,
+    [SYS_mknod] sys_mknod,
+    [SYS_unlink] sys_unlink,
+    [SYS_link] sys_link,
+    [SYS_mkdir] sys_mkdir,
+    [SYS_close] sys_close,
 };
 
 void syscall(void) {
   int num;
 
   num = proc->tf->eax;
-  if (num > 0 && num < NELEM(syscalls) && syscalls[num]) {
+  if(num > 0 && num < NELEM(syscalls) && syscalls[num]) {
     proc->tf->eax = syscalls[num]();
   } else {
     cprintf("%d %s: unknown sys call %d\n", proc->pid, proc->name, num);

--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -4,40 +4,40 @@
 // user code, and calls into file.c and fs.c.
 //
 
-#include "kernel/types.h"
 #include "kernel/defs.h"
-#include "kernel/param.h"
-#include "kernel/stat.h"
-#include "kernel/mmu.h"
-#include "kernel/proc.h"
-#include "kernel/fs.h"
-#include "kernel/file.h"
 #include "kernel/fcntl.h"
+#include "kernel/file.h"
+#include "kernel/fs.h"
+#include "kernel/mmu.h"
+#include "kernel/param.h"
+#include "kernel/proc.h"
+#include "kernel/stat.h"
+#include "kernel/types.h"
 
 // Fetch the nth word-sized system call argument as a file descriptor
 // and return both the descriptor and the corresponding struct file.
-static int argfd(int n, int *pfd, struct file **pf) {
+static int argfd(int n, int* pfd, struct file** pf) {
   int fd;
-  struct file *f;
+  struct file* f;
 
-  if (argint(n, &fd) < 0)
+  if(argint(n, &fd) < 0)
     return -1;
-  if (fd < 0 || fd >= NOFILE || (f = proc->ofile[fd]) == 0)
+  if(fd < 0 || fd >= NOFILE || (f = proc->ofile[fd]) == 0)
     return -1;
-  if (pfd)
+  if(pfd)
     *pfd = fd;
-  if (pf)
+  if(pf)
     *pf = f;
   return 0;
 }
 
 // Allocate a file descriptor for the given file.
 // Takes over file reference from caller on success.
-static int fdalloc(struct file *f) {
+static int fdalloc(struct file* f) {
   int fd;
 
-  for (fd = 0; fd < NOFILE; fd++) {
-    if (proc->ofile[fd] == 0) {
+  for(fd = 0; fd < NOFILE; fd++) {
+    if(proc->ofile[fd] == 0) {
       proc->ofile[fd] = f;
       return fd;
     }
@@ -46,42 +46,42 @@ static int fdalloc(struct file *f) {
 }
 
 int sys_dup(void) {
-  struct file *f;
+  struct file* f;
   int fd;
 
-  if (argfd(0, 0, &f) < 0)
+  if(argfd(0, 0, &f) < 0)
     return -1;
-  if ((fd = fdalloc(f)) < 0)
+  if((fd = fdalloc(f)) < 0)
     return -1;
   filedup(f);
   return fd;
 }
 
 int sys_read(void) {
-  struct file *f;
+  struct file* f;
   int n;
-  char *p;
+  char* p;
 
-  if (argfd(0, 0, &f) < 0 || argint(2, &n) < 0 || argptr(1, &p, n) < 0)
+  if(argfd(0, 0, &f) < 0 || argint(2, &n) < 0 || argptr(1, &p, n) < 0)
     return -1;
   return fileread(f, p, n);
 }
 
 int sys_write(void) {
-  struct file *f;
+  struct file* f;
   int n;
-  char *p;
+  char* p;
 
-  if (argfd(0, 0, &f) < 0 || argint(2, &n) < 0 || argptr(1, &p, n) < 0)
+  if(argfd(0, 0, &f) < 0 || argint(2, &n) < 0 || argptr(1, &p, n) < 0)
     return -1;
   return filewrite(f, p, n);
 }
 
 int sys_close(void) {
   int fd;
-  struct file *f;
+  struct file* f;
 
-  if (argfd(0, &fd, &f) < 0)
+  if(argfd(0, &fd, &f) < 0)
     return -1;
   proc->ofile[fd] = 0;
   fileclose(f);
@@ -89,10 +89,10 @@ int sys_close(void) {
 }
 
 int sys_fstat(void) {
-  struct file *f;
-  struct stat *st;
+  struct file* f;
+  struct stat* st;
 
-  if (argfd(0, 0, &f) < 0 || argptr(1, (void *)&st, sizeof(*st)) < 0)
+  if(argfd(0, 0, &f) < 0 || argptr(1, (void*) &st, sizeof(*st)) < 0)
     return -1;
   return filestat(f, st);
 }
@@ -102,17 +102,17 @@ int sys_link(void) {
   char name[DIRSIZ], *new, *old;
   struct inode *dp, *ip;
 
-  if (argstr(0, &old) < 0 || argstr(1, &new) < 0)
+  if(argstr(0, &old) < 0 || argstr(1, &new) < 0)
     return -1;
 
   begin_op();
-  if ((ip = namei(old)) == 0) {
+  if((ip = namei(old)) == 0) {
     end_op();
     return -1;
   }
 
   ilock(ip);
-  if (ip->type == T_DIR) {
+  if(ip->type == T_DIR) {
     iunlockput(ip);
     end_op();
     return -1;
@@ -122,10 +122,10 @@ int sys_link(void) {
   iupdate(ip);
   iunlock(ip);
 
-  if ((dp = nameiparent(new, name)) == 0)
+  if((dp = nameiparent(new, name)) == 0)
     goto bad;
   ilock(dp);
-  if (dp->dev != ip->dev || dirlink(dp, name, ip->inum) < 0) {
+  if(dp->dev != ip->dev || dirlink(dp, name, ip->inum) < 0) {
     iunlockput(dp);
     goto bad;
   }
@@ -146,31 +146,30 @@ bad:
 }
 
 // Is the directory dp empty except for "." and ".." ?
-static int isdirempty(struct inode *dp) {
+static int isdirempty(struct inode* dp) {
   int off;
   struct dirent de;
 
-  for (off = 2 * sizeof(de); off < dp->size; off += sizeof(de)) {
-    if (readi(dp, (char *)&de, off, sizeof(de)) != sizeof(de))
+  for(off = 2 * sizeof(de); off < dp->size; off += sizeof(de)) {
+    if(readi(dp, (char*) &de, off, sizeof(de)) != sizeof(de))
       panic("isdirempty: readi");
-    if (de.inum != 0)
+    if(de.inum != 0)
       return 0;
   }
   return 1;
 }
 
-// PAGEBREAK!
 int sys_unlink(void) {
   struct inode *ip, *dp;
   struct dirent de;
   char name[DIRSIZ], *path;
   uint off;
 
-  if (argstr(0, &path) < 0)
+  if(argstr(0, &path) < 0)
     return -1;
 
   begin_op();
-  if ((dp = nameiparent(path, name)) == 0) {
+  if((dp = nameiparent(path, name)) == 0) {
     end_op();
     return -1;
   }
@@ -178,24 +177,24 @@ int sys_unlink(void) {
   ilock(dp);
 
   // Cannot unlink "." or "..".
-  if (namecmp(name, ".") == 0 || namecmp(name, "..") == 0)
+  if(namecmp(name, ".") == 0 || namecmp(name, "..") == 0)
     goto bad;
 
-  if ((ip = dirlookup(dp, name, &off)) == 0)
+  if((ip = dirlookup(dp, name, &off)) == 0)
     goto bad;
   ilock(ip);
 
-  if (ip->nlink < 1)
+  if(ip->nlink < 1)
     panic("unlink: nlink < 1");
-  if (ip->type == T_DIR && !isdirempty(ip)) {
+  if(ip->type == T_DIR && !isdirempty(ip)) {
     iunlockput(ip);
     goto bad;
   }
 
   memset(&de, 0, sizeof(de));
-  if (writei(dp, (char *)&de, off, sizeof(de)) != sizeof(de))
+  if(writei(dp, (char*) &de, off, sizeof(de)) != sizeof(de))
     panic("unlink: writei");
-  if (ip->type == T_DIR) {
+  if(ip->type == T_DIR) {
     dp->nlink--;
     iupdate(dp);
   }
@@ -215,25 +214,25 @@ bad:
   return -1;
 }
 
-static struct inode *create(char *path, short type, short major, short minor) {
+static struct inode* create(char* path, short type, short major, short minor) {
   uint off;
   struct inode *ip, *dp;
   char name[DIRSIZ];
 
-  if ((dp = nameiparent(path, name)) == 0)
+  if((dp = nameiparent(path, name)) == 0)
     return 0;
   ilock(dp);
 
-  if ((ip = dirlookup(dp, name, &off)) != 0) {
+  if((ip = dirlookup(dp, name, &off)) != 0) {
     iunlockput(dp);
     ilock(ip);
-    if (type == T_FILE && ip->type == T_FILE)
+    if(type == T_FILE && ip->type == T_FILE)
       return ip;
     iunlockput(ip);
     return 0;
   }
 
-  if ((ip = ialloc(dp->dev, type)) == 0)
+  if((ip = ialloc(dp->dev, type)) == 0)
     panic("create: ialloc");
 
   ilock(ip);
@@ -242,15 +241,15 @@ static struct inode *create(char *path, short type, short major, short minor) {
   ip->nlink = 1;
   iupdate(ip);
 
-  if (type == T_DIR) { // Create . and .. entries.
-    dp->nlink++;       // for ".."
+  if(type == T_DIR) { // Create . and .. entries.
+    dp->nlink++;      // for ".."
     iupdate(dp);
     // No ip->nlink++ for ".": avoid cyclic ref count.
-    if (dirlink(ip, ".", ip->inum) < 0 || dirlink(ip, "..", dp->inum) < 0)
+    if(dirlink(ip, ".", ip->inum) < 0 || dirlink(ip, "..", dp->inum) < 0)
       panic("create dots");
   }
 
-  if (dirlink(dp, name, ip->inum) < 0)
+  if(dirlink(dp, name, ip->inum) < 0)
     panic("create: dirlink");
 
   iunlockput(dp);
@@ -259,37 +258,37 @@ static struct inode *create(char *path, short type, short major, short minor) {
 }
 
 int sys_open(void) {
-  char *path;
+  char* path;
   int fd, omode;
-  struct file *f;
-  struct inode *ip;
+  struct file* f;
+  struct inode* ip;
 
-  if (argstr(0, &path) < 0 || argint(1, &omode) < 0)
+  if(argstr(0, &path) < 0 || argint(1, &omode) < 0)
     return -1;
 
   begin_op();
 
-  if (omode & O_CREATE) {
+  if(omode & O_CREATE) {
     ip = create(path, T_FILE, 0, 0);
-    if (ip == 0) {
+    if(ip == 0) {
       end_op();
       return -1;
     }
   } else {
-    if ((ip = namei(path)) == 0) {
+    if((ip = namei(path)) == 0) {
       end_op();
       return -1;
     }
     ilock(ip);
-    if (ip->type == T_DIR && omode != O_RDONLY) {
+    if(ip->type == T_DIR && omode != O_RDONLY) {
       iunlockput(ip);
       end_op();
       return -1;
     }
   }
 
-  if ((f = filealloc()) == 0 || (fd = fdalloc(f)) < 0) {
-    if (f)
+  if((f = filealloc()) == 0 || (fd = fdalloc(f)) < 0) {
+    if(f)
       fileclose(f);
     iunlockput(ip);
     end_op();
@@ -307,11 +306,11 @@ int sys_open(void) {
 }
 
 int sys_mkdir(void) {
-  char *path;
-  struct inode *ip;
+  char* path;
+  struct inode* ip;
 
   begin_op();
-  if (argstr(0, &path) < 0 || (ip = create(path, T_DIR, 0, 0)) == 0) {
+  if(argstr(0, &path) < 0 || (ip = create(path, T_DIR, 0, 0)) == 0) {
     end_op();
     return -1;
   }
@@ -321,13 +320,13 @@ int sys_mkdir(void) {
 }
 
 int sys_mknod(void) {
-  struct inode *ip;
-  char *path;
+  struct inode* ip;
+  char* path;
   int len;
   int major, minor;
 
   begin_op();
-  if ((len = argstr(0, &path)) < 0 || argint(1, &major) < 0 ||
+  if((len = argstr(0, &path)) < 0 || argint(1, &major) < 0 ||
       argint(2, &minor) < 0 || (ip = create(path, T_DEV, major, minor)) == 0) {
     end_op();
     return -1;
@@ -338,16 +337,16 @@ int sys_mknod(void) {
 }
 
 int sys_chdir(void) {
-  char *path;
-  struct inode *ip;
+  char* path;
+  struct inode* ip;
 
   begin_op();
-  if (argstr(0, &path) < 0 || (ip = namei(path)) == 0) {
+  if(argstr(0, &path) < 0 || (ip = namei(path)) == 0) {
     end_op();
     return -1;
   }
   ilock(ip);
-  if (ip->type != T_DIR) {
+  if(ip->type != T_DIR) {
     iunlockput(ip);
     end_op();
     return -1;
@@ -364,37 +363,37 @@ int sys_exec(void) {
   int i;
   uint uargv, uarg;
 
-  if (argstr(0, &path) < 0 || argint(1, (int *)&uargv) < 0) {
+  if(argstr(0, &path) < 0 || argint(1, (int*) &uargv) < 0) {
     return -1;
   }
   memset(argv, 0, sizeof(argv));
-  for (i = 0;; i++) {
-    if (i >= NELEM(argv))
+  for(i = 0;; i++) {
+    if(i >= NELEM(argv))
       return -1;
-    if (fetchint(uargv + 4 * i, (int *)&uarg) < 0)
+    if(fetchint(uargv + 4 * i, (int*) &uarg) < 0)
       return -1;
-    if (uarg == 0) {
+    if(uarg == 0) {
       argv[i] = 0;
       break;
     }
-    if (fetchstr(uarg, &argv[i]) < 0)
+    if(fetchstr(uarg, &argv[i]) < 0)
       return -1;
   }
   return exec(path, argv);
 }
 
 int sys_pipe(void) {
-  int *fd;
+  int* fd;
   struct file *rf, *wf;
   int fd0, fd1;
 
-  if (argptr(0, (void *)&fd, 2 * sizeof(fd[0])) < 0)
+  if(argptr(0, (void*) &fd, 2 * sizeof(fd[0])) < 0)
     return -1;
-  if (pipealloc(&rf, &wf) < 0)
+  if(pipealloc(&rf, &wf) < 0)
     return -1;
   fd0 = -1;
-  if ((fd0 = fdalloc(rf)) < 0 || (fd1 = fdalloc(wf)) < 0) {
-    if (fd0 >= 0)
+  if((fd0 = fdalloc(rf)) < 0 || (fd1 = fdalloc(wf)) < 0) {
+    if(fd0 >= 0)
       proc->ofile[fd0] = 0;
     fileclose(rf);
     fileclose(wf);

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -1,39 +1,45 @@
-#include "kernel/types.h"
-#include "kernel/x86.h"
-#include "kernel/defs.h"
 #include "kernel/date.h"
-#include "kernel/param.h"
+#include "kernel/defs.h"
 #include "kernel/memlayout.h"
 #include "kernel/mmu.h"
+#include "kernel/param.h"
 #include "kernel/proc.h"
+#include "kernel/types.h"
+#include "kernel/x86.h"
 
-int sys_fork(void) { return fork(); }
+int sys_fork(void) {
+  return fork();
+}
 
 int sys_exit(void) {
   exit();
   return 0; // not reached
 }
 
-int sys_wait(void) { return wait(); }
+int sys_wait(void) {
+  return wait();
+}
 
 int sys_kill(void) {
   int pid;
 
-  if (argint(0, &pid) < 0)
+  if(argint(0, &pid) < 0)
     return -1;
   return kill(pid);
 }
 
-int sys_getpid(void) { return proc->pid; }
+int sys_getpid(void) {
+  return proc->pid;
+}
 
 int sys_sbrk(void) {
   int addr;
   int n;
 
-  if (argint(0, &n) < 0)
+  if(argint(0, &n) < 0)
     return -1;
   addr = proc->sz;
-  if (growproc(n) < 0)
+  if(growproc(n) < 0)
     return -1;
   return addr;
 }
@@ -42,12 +48,12 @@ int sys_sleep(void) {
   int n;
   uint ticks0;
 
-  if (argint(0, &n) < 0)
+  if(argint(0, &n) < 0)
     return -1;
   acquire(&tickslock);
   ticks0 = ticks;
-  while (ticks - ticks0 < n) {
-    if (proc->killed) {
+  while(ticks - ticks0 < n) {
+    if(proc->killed) {
       release(&tickslock);
       return -1;
     }

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -2,9 +2,9 @@
 // Only used on uniprocessors;
 // SMP machines use the local APIC timer.
 
-#include "kernel/types.h"
 #include "kernel/defs.h"
 #include "kernel/traps.h"
+#include "kernel/types.h"
 #include "kernel/x86.h"
 
 #define IO_TIMER1 0x040 // 8253 Timer #1

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -1,12 +1,12 @@
-#include "kernel/types.h"
 #include "kernel/defs.h"
-#include "kernel/param.h"
 #include "kernel/memlayout.h"
 #include "kernel/mmu.h"
+#include "kernel/param.h"
 #include "kernel/proc.h"
-#include "kernel/x86.h"
-#include "kernel/traps.h"
 #include "kernel/spinlock.h"
+#include "kernel/traps.h"
+#include "kernel/types.h"
+#include "kernel/x86.h"
 
 // Interrupt descriptor table (shared by all CPUs).
 struct gatedesc idt[256];
@@ -17,86 +17,86 @@ uint ticks;
 void tvinit(void) {
   int i;
 
-  for (i = 0; i < 256; i++)
+  for(i = 0; i < 256; i++)
     SETGATE(idt[i], 0, SEG_KCODE << 3, vectors[i], 0);
   SETGATE(idt[T_SYSCALL], 1, SEG_KCODE << 3, vectors[T_SYSCALL], DPL_USER);
 
   initlock(&tickslock, "time");
 }
 
-void idtinit(void) { lidt(idt, sizeof(idt)); }
+void idtinit(void) {
+  lidt(idt, sizeof(idt));
+}
 
-// PAGEBREAK: 41
-void trap(struct trapframe *tf) {
-  if (tf->trapno == T_SYSCALL) {
-    if (proc->killed)
+void trap(struct trapframe* tf) {
+  if(tf->trapno == T_SYSCALL) {
+    if(proc->killed)
       exit();
     proc->tf = tf;
     syscall();
-    if (proc->killed)
+    if(proc->killed)
       exit();
     return;
   }
 
-  switch (tf->trapno) {
-  case T_IRQ0 + IRQ_TIMER:
-    if (cpu->id == 0) {
-      acquire(&tickslock);
-      ticks++;
-      wakeup(&ticks);
-      release(&tickslock);
-    }
-    lapiceoi();
-    break;
-  case T_IRQ0 + IRQ_IDE:
-    ideintr();
-    lapiceoi();
-    break;
-  case T_IRQ0 + IRQ_IDE + 1:
-    // Bochs generates spurious IDE1 interrupts.
-    break;
-  case T_IRQ0 + IRQ_KBD:
-    kbdintr();
-    lapiceoi();
-    break;
-  case T_IRQ0 + IRQ_COM1:
-    uartintr();
-    lapiceoi();
-    break;
-  case T_IRQ0 + 7:
-  case T_IRQ0 + IRQ_SPURIOUS:
-    cprintf("cpu%d: spurious interrupt at %x:%x\n", cpu->id, tf->cs, tf->eip);
-    lapiceoi();
-    break;
+  switch(tf->trapno) {
+    case T_IRQ0 + IRQ_TIMER:
+      if(cpu->id == 0) {
+        acquire(&tickslock);
+        ticks++;
+        wakeup(&ticks);
+        release(&tickslock);
+      }
+      lapiceoi();
+      break;
+    case T_IRQ0 + IRQ_IDE:
+      ideintr();
+      lapiceoi();
+      break;
+    case T_IRQ0 + IRQ_IDE + 1:
+      // Bochs generates spurious IDE1 interrupts.
+      break;
+    case T_IRQ0 + IRQ_KBD:
+      kbdintr();
+      lapiceoi();
+      break;
+    case T_IRQ0 + IRQ_COM1:
+      uartintr();
+      lapiceoi();
+      break;
+    case T_IRQ0 + 7:
+    case T_IRQ0 + IRQ_SPURIOUS:
+      cprintf("cpu%d: spurious interrupt at %x:%x\n", cpu->id, tf->cs, tf->eip);
+      lapiceoi();
+      break;
 
-  // PAGEBREAK: 13
-  default:
-    if (proc == 0 || (tf->cs & 3) == 0) {
-      // In kernel, it must be our mistake.
-      cprintf("unexpected trap %d from cpu %d eip %x (cr2=0x%x)\n", tf->trapno,
-              cpu->id, tf->eip, rcr2());
-      panic("trap");
-    }
-    // In user space, assume process misbehaved.
-    cprintf("pid %d %s: trap %d err %d on cpu %d "
-            "eip 0x%x addr 0x%x--kill proc\n",
-            proc->pid, proc->name, tf->trapno, tf->err, cpu->id, tf->eip,
-            rcr2());
-    proc->killed = 1;
+    default:
+      if(proc == 0 || (tf->cs & 3) == 0) {
+        // In kernel, it must be our mistake.
+        cprintf("unexpected trap %d from cpu %d eip %x (cr2=0x%x)\n",
+            tf->trapno, cpu->id, tf->eip, rcr2());
+        panic("trap");
+      }
+      // In user space, assume process misbehaved.
+      cprintf(
+          "pid %d %s: trap %d err %d on cpu %d "
+          "eip 0x%x addr 0x%x--kill proc\n",
+          proc->pid, proc->name, tf->trapno, tf->err, cpu->id, tf->eip, rcr2());
+      proc->killed = 1;
   }
 
   // Force process exit if it has been killed and is in user space.
   // (If it is still executing in the kernel, let it keep running
   // until it gets to the regular system call return.)
-  if (proc && proc->killed && (tf->cs & 3) == DPL_USER)
+  if(proc && proc->killed && (tf->cs & 3) == DPL_USER)
     exit();
 
   // Force process to give up CPU on clock tick.
   // If interrupts were on while locks held, would need to check nlock.
-  if (proc && proc->state == RUNNING && tf->trapno == T_IRQ0 + IRQ_TIMER)
+  if(proc && proc->state == RUNNING && tf->trapno == T_IRQ0 + IRQ_TIMER)
     yield();
 
   // Check if the process has been killed since we yielded
-  if (proc && proc->killed && (tf->cs & 3) == DPL_USER)
+  if(proc && proc->killed && (tf->cs & 3) == DPL_USER)
     exit();
 }

--- a/kernel/trapasm.S
+++ b/kernel/trapasm.S
@@ -9,7 +9,7 @@ alltraps:
   pushl %fs
   pushl %gs
   pushal
-  
+
   # Set up data and per-cpu segments.
   movw $(SEG_KDATA<<3), %ax
   movw %ax, %ds

--- a/kernel/uart.c
+++ b/kernel/uart.c
@@ -1,14 +1,14 @@
 // Intel 8250 serial port (UART).
 
-#include "kernel/types.h"
 #include "kernel/defs.h"
-#include "kernel/param.h"
-#include "kernel/traps.h"
-#include "kernel/spinlock.h"
-#include "kernel/fs.h"
 #include "kernel/file.h"
+#include "kernel/fs.h"
 #include "kernel/mmu.h"
+#include "kernel/param.h"
 #include "kernel/proc.h"
+#include "kernel/spinlock.h"
+#include "kernel/traps.h"
+#include "kernel/types.h"
 #include "kernel/x86.h"
 
 #define COM1 0x3f8
@@ -16,7 +16,7 @@
 static int uart; // is there a uart?
 
 void uartinit(void) {
-  char *p;
+  char* p;
 
   // Turn off the FIFO
   outb(COM1 + 2, 0);
@@ -30,7 +30,7 @@ void uartinit(void) {
   outb(COM1 + 1, 0x01); // Enable receive interrupts.
 
   // If status is 0xFF, no serial port.
-  if (inb(COM1 + 5) == 0xFF)
+  if(inb(COM1 + 5) == 0xFF)
     return;
   uart = 1;
 
@@ -42,26 +42,28 @@ void uartinit(void) {
   ioapicenable(IRQ_COM1, 0);
 
   // Announce that we're here.
-  for (p = "xv6...\n"; *p; p++)
+  for(p = "xv6...\n"; *p; p++)
     uartputc(*p);
 }
 
 void uartputc(int c) {
   int i;
 
-  if (!uart)
+  if(!uart)
     return;
-  for (i = 0; i < 128 && !(inb(COM1 + 5) & 0x20); i++)
+  for(i = 0; i < 128 && !(inb(COM1 + 5) & 0x20); i++)
     microdelay(10);
   outb(COM1 + 0, c);
 }
 
 static int uartgetc(void) {
-  if (!uart)
+  if(!uart)
     return -1;
-  if (!(inb(COM1 + 5) & 0x01))
+  if(!(inb(COM1 + 5) & 0x01))
     return -1;
   return inb(COM1 + 0);
 }
 
-void uartintr(void) { consoleintr(uartgetc); }
+void uartintr(void) {
+  consoleintr(uartgetc);
+}

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -1,20 +1,20 @@
-#include "kernel/param.h"
-#include "kernel/types.h"
 #include "kernel/defs.h"
-#include "kernel/x86.h"
+#include "kernel/elf.h"
 #include "kernel/memlayout.h"
 #include "kernel/mmu.h"
+#include "kernel/param.h"
 #include "kernel/proc.h"
-#include "kernel/elf.h"
+#include "kernel/types.h"
+#include "kernel/x86.h"
 
 extern char data[]; // defined by kernel.ld
-pde_t *kpgdir;      // for use in scheduler()
+pde_t* kpgdir;      // for use in scheduler()
 struct segdesc gdt[NSEGS];
 
 // Set up CPU's kernel segment descriptors.
 // Run once on entry on each CPU.
 void seginit(void) {
-  struct cpu *c;
+  struct cpu* c;
 
   // Map "logical" addresses to virtual addresses using identity map.
   // Cannot share a CODE descriptor for both kernel and user
@@ -40,15 +40,15 @@ void seginit(void) {
 // Return the address of the PTE in page table pgdir
 // that corresponds to virtual address va.  If alloc!=0,
 // create any required page table pages.
-static pte_t *walkpgdir(pde_t *pgdir, const void *va, int alloc) {
-  pde_t *pde;
-  pte_t *pgtab;
+static pte_t* walkpgdir(pde_t* pgdir, const void* va, int alloc) {
+  pde_t* pde;
+  pte_t* pgtab;
 
   pde = &pgdir[PDX(va)];
-  if (*pde & PTE_P) {
-    pgtab = (pte_t *)p2v(PTE_ADDR(*pde));
+  if(*pde & PTE_P) {
+    pgtab = (pte_t*) p2v(PTE_ADDR(*pde));
   } else {
-    if (!alloc || (pgtab = (pte_t *)kalloc()) == 0)
+    if(!alloc || (pgtab = (pte_t*) kalloc()) == 0)
       return 0;
     // Make sure all those PTE_P bits are zero.
     memset(pgtab, 0, PGSIZE);
@@ -63,19 +63,19 @@ static pte_t *walkpgdir(pde_t *pgdir, const void *va, int alloc) {
 // Create PTEs for virtual addresses starting at va that refer to
 // physical addresses starting at pa. va and size might not
 // be page-aligned.
-static int mappages(pde_t *pgdir, void *va, uint size, uint pa, int perm) {
+static int mappages(pde_t* pgdir, void* va, uint size, uint pa, int perm) {
   char *a, *last;
-  pte_t *pte;
+  pte_t* pte;
 
-  a = (char *)PGROUNDDOWN((uint)va);
-  last = (char *)PGROUNDDOWN(((uint)va) + size - 1);
-  for (;;) {
-    if ((pte = walkpgdir(pgdir, a, 1)) == 0)
+  a = (char*) PGROUNDDOWN((uint) va);
+  last = (char*) PGROUNDDOWN(((uint) va) + size - 1);
+  for(;;) {
+    if((pte = walkpgdir(pgdir, a, 1)) == 0)
       return -1;
-    if (*pte & PTE_P)
+    if(*pte & PTE_P)
       panic("remap");
     *pte = pa | perm | PTE_P;
-    if (a == last)
+    if(a == last)
       break;
     a += PGSIZE;
     pa += PGSIZE;
@@ -107,30 +107,30 @@ static int mappages(pde_t *pgdir, void *va, uint size, uint pa, int perm) {
 // This table defines the kernel's mappings, which are present in
 // every process's page table.
 static struct kmap {
-  void *virt;
+  void* virt;
   uint phys_start;
   uint phys_end;
   int perm;
 } kmap[] = {
-    {(void *)KERNBASE, 0, EXTMEM, PTE_W},            // I/O space
-    {(void *)KERNLINK, V2P(KERNLINK), V2P(data), 0}, // kern text+rodata
-    {(void *)data, V2P(data), PHYSTOP, PTE_W},       // kern data+memory
-    {(void *)DEVSPACE, DEVSPACE, 0, PTE_W},          // more devices
+    {(void*) KERNBASE, 0, EXTMEM, PTE_W},            // I/O space
+    {(void*) KERNLINK, V2P(KERNLINK), V2P(data), 0}, // kern text+rodata
+    {(void*) data, V2P(data), PHYSTOP, PTE_W},       // kern data+memory
+    {(void*) DEVSPACE, DEVSPACE, 0, PTE_W},          // more devices
 };
 
 // Set up kernel part of a page table.
-pde_t *setupkvm(void) {
-  pde_t *pgdir;
-  struct kmap *k;
+pde_t* setupkvm(void) {
+  pde_t* pgdir;
+  struct kmap* k;
 
-  if ((pgdir = (pde_t *)kalloc()) == 0)
+  if((pgdir = (pde_t*) kalloc()) == 0)
     return 0;
   memset(pgdir, 0, PGSIZE);
-  if (p2v(PHYSTOP) > (void *)DEVSPACE)
+  if(p2v(PHYSTOP) > (void*) DEVSPACE)
     panic("PHYSTOP too high");
-  for (k = kmap; k < &kmap[NELEM(kmap)]; k++)
-    if (mappages(pgdir, k->virt, k->phys_end - k->phys_start,
-                 (uint)k->phys_start, k->perm) < 0)
+  for(k = kmap; k < &kmap[NELEM(kmap)]; k++)
+    if(mappages(pgdir, k->virt, k->phys_end - k->phys_start,
+           (uint) k->phys_start, k->perm) < 0)
       return 0;
   return pgdir;
 }
@@ -149,14 +149,14 @@ void switchkvm(void) {
 }
 
 // Switch TSS and h/w page table to correspond to process p.
-void switchuvm(struct proc *p) {
+void switchuvm(struct proc* p) {
   pushcli();
   cpu->gdt[SEG_TSS] = SEG16(STS_T32A, &cpu->ts, sizeof(cpu->ts) - 1, 0);
   cpu->gdt[SEG_TSS].s = 0;
   cpu->ts.ss0 = SEG_KDATA << 3;
-  cpu->ts.esp0 = (uint)proc->kstack + KSTACKSIZE;
+  cpu->ts.esp0 = (uint) proc->kstack + KSTACKSIZE;
   ltr(SEG_TSS << 3);
-  if (p->pgdir == 0)
+  if(p->pgdir == 0)
     panic("switchuvm: no pgdir");
   lcr3(v2p(p->pgdir)); // switch to new address space
   popcli();
@@ -164,10 +164,10 @@ void switchuvm(struct proc *p) {
 
 // Load the initcode into address 0 of pgdir.
 // sz must be less than a page.
-void inituvm(pde_t *pgdir, char *init, uint sz) {
-  char *mem;
+void inituvm(pde_t* pgdir, char* init, uint sz) {
+  char* mem;
 
-  if (sz >= PGSIZE)
+  if(sz >= PGSIZE)
     panic("inituvm: more than a page");
   mem = kalloc();
   memset(mem, 0, PGSIZE);
@@ -177,21 +177,21 @@ void inituvm(pde_t *pgdir, char *init, uint sz) {
 
 // Load a program segment into pgdir.  addr must be page-aligned
 // and the pages from addr to addr+sz must already be mapped.
-int loaduvm(pde_t *pgdir, char *addr, struct inode *ip, uint offset, uint sz) {
+int loaduvm(pde_t* pgdir, char* addr, struct inode* ip, uint offset, uint sz) {
   uint i, pa, n;
-  pte_t *pte;
+  pte_t* pte;
 
-  if ((uint)addr % PGSIZE != 0)
+  if((uint) addr % PGSIZE != 0)
     panic("loaduvm: addr must be page aligned");
-  for (i = 0; i < sz; i += PGSIZE) {
-    if ((pte = walkpgdir(pgdir, addr + i, 0)) == 0)
+  for(i = 0; i < sz; i += PGSIZE) {
+    if((pte = walkpgdir(pgdir, addr + i, 0)) == 0)
       panic("loaduvm: address should exist");
     pa = PTE_ADDR(*pte);
-    if (sz - i < PGSIZE)
+    if(sz - i < PGSIZE)
       n = sz - i;
     else
       n = PGSIZE;
-    if (readi(ip, p2v(pa), offset + i, n) != n)
+    if(readi(ip, p2v(pa), offset + i, n) != n)
       return -1;
   }
   return 0;
@@ -199,25 +199,25 @@ int loaduvm(pde_t *pgdir, char *addr, struct inode *ip, uint offset, uint sz) {
 
 // Allocate page tables and physical memory to grow process from oldsz to
 // newsz, which need not be page aligned.  Returns new size or 0 on error.
-int allocuvm(pde_t *pgdir, uint oldsz, uint newsz) {
-  char *mem;
+int allocuvm(pde_t* pgdir, uint oldsz, uint newsz) {
+  char* mem;
   uint a;
 
-  if (newsz >= KERNBASE)
+  if(newsz >= KERNBASE)
     return 0;
-  if (newsz < oldsz)
+  if(newsz < oldsz)
     return oldsz;
 
   a = PGROUNDUP(oldsz);
-  for (; a < newsz; a += PGSIZE) {
+  for(; a < newsz; a += PGSIZE) {
     mem = kalloc();
-    if (mem == 0) {
+    if(mem == 0) {
       cprintf("allocuvm out of memory\n");
       deallocuvm(pgdir, newsz, oldsz);
       return 0;
     }
     memset(mem, 0, PGSIZE);
-    mappages(pgdir, (char *)a, PGSIZE, v2p(mem), PTE_W | PTE_U);
+    mappages(pgdir, (char*) a, PGSIZE, v2p(mem), PTE_W | PTE_U);
   }
   return newsz;
 }
@@ -226,23 +226,23 @@ int allocuvm(pde_t *pgdir, uint oldsz, uint newsz) {
 // newsz.  oldsz and newsz need not be page-aligned, nor does newsz
 // need to be less than oldsz.  oldsz can be larger than the actual
 // process size.  Returns the new process size.
-int deallocuvm(pde_t *pgdir, uint oldsz, uint newsz) {
-  pte_t *pte;
+int deallocuvm(pde_t* pgdir, uint oldsz, uint newsz) {
+  pte_t* pte;
   uint a, pa;
 
-  if (newsz >= oldsz)
+  if(newsz >= oldsz)
     return oldsz;
 
   a = PGROUNDUP(newsz);
-  for (; a < oldsz; a += PGSIZE) {
-    pte = walkpgdir(pgdir, (char *)a, 0);
-    if (!pte)
+  for(; a < oldsz; a += PGSIZE) {
+    pte = walkpgdir(pgdir, (char*) a, 0);
+    if(!pte)
       a += (NPTENTRIES - 1) * PGSIZE;
-    else if ((*pte & PTE_P) != 0) {
+    else if((*pte & PTE_P) != 0) {
       pa = PTE_ADDR(*pte);
-      if (pa == 0)
+      if(pa == 0)
         panic("kfree");
-      char *v = p2v(pa);
+      char* v = p2v(pa);
       kfree(v);
       *pte = 0;
     }
@@ -252,53 +252,53 @@ int deallocuvm(pde_t *pgdir, uint oldsz, uint newsz) {
 
 // Free a page table and all the physical memory pages
 // in the user part.
-void freevm(pde_t *pgdir) {
+void freevm(pde_t* pgdir) {
   uint i;
 
-  if (pgdir == 0)
+  if(pgdir == 0)
     panic("freevm: no pgdir");
   deallocuvm(pgdir, KERNBASE, 0);
-  for (i = 0; i < NPDENTRIES; i++) {
-    if (pgdir[i] & PTE_P) {
-      char *v = p2v(PTE_ADDR(pgdir[i]));
+  for(i = 0; i < NPDENTRIES; i++) {
+    if(pgdir[i] & PTE_P) {
+      char* v = p2v(PTE_ADDR(pgdir[i]));
       kfree(v);
     }
   }
-  kfree((char *)pgdir);
+  kfree((char*) pgdir);
 }
 
 // Clear PTE_U on a page. Used to create an inaccessible
 // page beneath the user stack.
-void clearpteu(pde_t *pgdir, char *uva) {
-  pte_t *pte;
+void clearpteu(pde_t* pgdir, char* uva) {
+  pte_t* pte;
 
   pte = walkpgdir(pgdir, uva, 0);
-  if (pte == 0)
+  if(pte == 0)
     panic("clearpteu");
   *pte &= ~PTE_U;
 }
 
 // Given a parent process's page table, create a copy
 // of it for a child.
-pde_t *copyuvm(pde_t *pgdir, uint sz) {
-  pde_t *d;
-  pte_t *pte;
+pde_t* copyuvm(pde_t* pgdir, uint sz) {
+  pde_t* d;
+  pte_t* pte;
   uint pa, i, flags;
-  char *mem;
+  char* mem;
 
-  if ((d = setupkvm()) == 0)
+  if((d = setupkvm()) == 0)
     return 0;
-  for (i = 0; i < sz; i += PGSIZE) {
-    if ((pte = walkpgdir(pgdir, (void *)i, 0)) == 0)
+  for(i = 0; i < sz; i += PGSIZE) {
+    if((pte = walkpgdir(pgdir, (void*) i, 0)) == 0)
       panic("copyuvm: pte should exist");
-    if (!(*pte & PTE_P))
+    if(!(*pte & PTE_P))
       panic("copyuvm: page not present");
     pa = PTE_ADDR(*pte);
     flags = PTE_FLAGS(*pte);
-    if ((mem = kalloc()) == 0)
+    if((mem = kalloc()) == 0)
       goto bad;
-    memmove(mem, (char *)p2v(pa), PGSIZE);
-    if (mappages(d, (void *)i, PGSIZE, v2p(mem), flags) < 0)
+    memmove(mem, (char*) p2v(pa), PGSIZE);
+    if(mappages(d, (void*) i, PGSIZE, v2p(mem), flags) < 0)
       goto bad;
   }
   return d;
@@ -308,34 +308,33 @@ bad:
   return 0;
 }
 
-// PAGEBREAK!
 // Map user virtual address to kernel address.
-char *uva2ka(pde_t *pgdir, char *uva) {
-  pte_t *pte;
+char* uva2ka(pde_t* pgdir, char* uva) {
+  pte_t* pte;
 
   pte = walkpgdir(pgdir, uva, 0);
-  if ((*pte & PTE_P) == 0)
+  if((*pte & PTE_P) == 0)
     return 0;
-  if ((*pte & PTE_U) == 0)
+  if((*pte & PTE_U) == 0)
     return 0;
-  return (char *)p2v(PTE_ADDR(*pte));
+  return (char*) p2v(PTE_ADDR(*pte));
 }
 
 // Copy len bytes from p to user address va in page table pgdir.
 // Most useful when pgdir is not the current page table.
 // uva2ka ensures this only works for PTE_U pages.
-int copyout(pde_t *pgdir, uint va, void *p, uint len) {
+int copyout(pde_t* pgdir, uint va, void* p, uint len) {
   char *buf, *pa0;
   uint n, va0;
 
-  buf = (char *)p;
-  while (len > 0) {
-    va0 = (uint)PGROUNDDOWN(va);
-    pa0 = uva2ka(pgdir, (char *)va0);
-    if (pa0 == 0)
+  buf = (char*) p;
+  while(len > 0) {
+    va0 = (uint) PGROUNDDOWN(va);
+    pa0 = uva2ka(pgdir, (char*) va0);
+    if(pa0 == 0)
       return -1;
     n = PGSIZE - (va - va0);
-    if (n > len)
+    if(n > len)
       n = len;
     memmove(pa0 + (va - va0), buf, n);
     len -= n;
@@ -344,10 +343,3 @@ int copyout(pde_t *pgdir, uint va, void *p, uint len) {
   }
   return 0;
 }
-
-// PAGEBREAK!
-// Blank page.
-// PAGEBREAK!
-// Blank page.
-// PAGEBREAK!
-// Blank page.

--- a/kernel/x86.h
+++ b/kernel/x86.h
@@ -12,7 +12,7 @@ static inline uchar inb(ushort port) {
   return data;
 }
 
-static inline void insl(int port, void *addr, int cnt) {
+static inline void insl(int port, void* addr, int cnt) {
   asm volatile("cld; rep insl"
                : "=D"(addr), "=c"(cnt)
                : "d"(port), "0"(addr), "1"(cnt)
@@ -27,21 +27,21 @@ static inline void outw(ushort port, ushort data) {
   asm volatile("out %0,%1" : : "a"(data), "d"(port));
 }
 
-static inline void outsl(int port, const void *addr, int cnt) {
+static inline void outsl(int port, const void* addr, int cnt) {
   asm volatile("cld; rep outsl"
                : "=S"(addr), "=c"(cnt)
                : "d"(port), "0"(addr), "1"(cnt)
                : "cc");
 }
 
-static inline void stosb(void *addr, int data, int cnt) {
+static inline void stosb(void* addr, int data, int cnt) {
   asm volatile("cld; rep stosb"
                : "=D"(addr), "=c"(cnt)
                : "0"(addr), "1"(cnt), "a"(data)
                : "memory", "cc");
 }
 
-static inline void stosl(void *addr, int data, int cnt) {
+static inline void stosl(void* addr, int data, int cnt) {
   asm volatile("cld; rep stosl"
                : "=D"(addr), "=c"(cnt)
                : "0"(addr), "1"(cnt), "a"(data)
@@ -50,29 +50,31 @@ static inline void stosl(void *addr, int data, int cnt) {
 
 struct segdesc;
 
-static inline void lgdt(struct segdesc *p, int size) {
+static inline void lgdt(struct segdesc* p, int size) {
   volatile ushort pd[3];
 
   pd[0] = size - 1;
-  pd[1] = (uint)p;
-  pd[2] = (uint)p >> 16;
+  pd[1] = (uint) p;
+  pd[2] = (uint) p >> 16;
 
   asm volatile("lgdt (%0)" : : "r"(pd));
 }
 
 struct gatedesc;
 
-static inline void lidt(struct gatedesc *p, int size) {
+static inline void lidt(struct gatedesc* p, int size) {
   volatile ushort pd[3];
 
   pd[0] = size - 1;
-  pd[1] = (uint)p;
-  pd[2] = (uint)p >> 16;
+  pd[1] = (uint) p;
+  pd[2] = (uint) p >> 16;
 
   asm volatile("lidt (%0)" : : "r"(pd));
 }
 
-static inline void ltr(ushort sel) { asm volatile("ltr %0" : : "r"(sel)); }
+static inline void ltr(ushort sel) {
+  asm volatile("ltr %0" : : "r"(sel));
+}
 
 static inline uint readeflags(void) {
   uint eflags;
@@ -84,13 +86,19 @@ static inline void loadgs(ushort v) {
   asm volatile("movw %0, %%gs" : : "r"(v));
 }
 
-static inline void cli(void) { asm volatile("cli"); }
+static inline void cli(void) {
+  asm volatile("cli");
+}
 
-static inline void sti(void) { asm volatile("sti"); }
+static inline void sti(void) {
+  asm volatile("sti");
+}
 
-static inline void hlt(void) { asm volatile("hlt"); }
+static inline void hlt(void) {
+  asm volatile("hlt");
+}
 
-static inline uint xchg(volatile uint *addr, uint newval) {
+static inline uint xchg(volatile uint* addr, uint newval) {
   uint result;
 
   // The + in "+m" denotes a read-modify-write operand.
@@ -111,7 +119,6 @@ static inline void lcr3(uint val) {
   asm volatile("movl %0,%%cr3" : : "r"(val));
 }
 
-// PAGEBREAK: 36
 //  Layout of the trap frame built on the stack by the
 //  hardware and by trapasm.S, and passed to trap().
 struct trapframe {

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -11,11 +11,11 @@
 #include "kernel/stat.h"
 
 #ifndef static_assert
-#define static_assert(a, b)                                                   \
-  do {                                                                        \
-    switch(0)                                                                 \
-    case 0:                                                                   \
-    case(a):;                                                                 \
+#define static_assert(a, b)                                                    \
+  do {                                                                         \
+    switch(0)                                                                  \
+    case 0:                                                                    \
+    case(a):;                                                                  \
   } while(0)
 #endif
 
@@ -98,8 +98,9 @@ int main(int argc, char* argv[]) {
   sb.inodestart = xint(2 + nlog);
   sb.bmapstart = xint(2 + nlog + ninodeblocks);
 
-  printf("nmeta %d (boot, super, log blocks %u inode blocks %u, bitmap blocks "
-         "%u) blocks %d total %d\n",
+  printf(
+      "nmeta %d (boot, super, log blocks %u inode blocks %u, bitmap blocks "
+      "%u) blocks %d total %d\n",
       nmeta, nlog, ninodeblocks, nbitmap, nblocks, FSSIZE);
 
   freeblock = nmeta; // the first free block that we can allocate
@@ -124,14 +125,14 @@ int main(int argc, char* argv[]) {
   strcpy(de.name, "..");
   iappend(rootino, &de, sizeof(de));
 
-  for(i = 2; i < argc; i++){
+  for(i = 2; i < argc; i++) {
     // get rid of "user/"
-    char *shortname;
+    char* shortname;
     if(strncmp(argv[i], "user/", 5) == 0)
       shortname = argv[i] + 5;
     else
       shortname = argv[i];
-    
+
     assert(index(shortname, '/') == 0);
 
     if((fd = open(argv[i], 0)) < 0) {

--- a/user/cat.c
+++ b/user/cat.c
@@ -1,5 +1,3 @@
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
 
 char buf[512];
@@ -7,24 +5,24 @@ char buf[512];
 void cat(int fd) {
   int n;
 
-  while ((n = read(fd, buf, sizeof(buf))) > 0)
+  while((n = read(fd, buf, sizeof(buf))) > 0)
     write(1, buf, n);
-  if (n < 0) {
+  if(n < 0) {
     printf(1, "cat: read error\n");
     exit();
   }
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   int fd, i;
 
-  if (argc <= 1) {
+  if(argc <= 1) {
     cat(0);
     exit();
   }
 
-  for (i = 1; i < argc; i++) {
-    if ((fd = open(argv[i], 0)) < 0) {
+  for(i = 1; i < argc; i++) {
+    if((fd = open(argv[i], 0)) < 0) {
       printf(1, "cat: cannot open %s\n", argv[i]);
       exit();
     }

--- a/user/echo.c
+++ b/user/echo.c
@@ -1,11 +1,7 @@
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
 
-int main(int argc, char *argv[]) {
-  int i;
-
-  for (i = 1; i < argc; i++)
+int main(int argc, char* argv[]) {
+  for(int i = 1; i < argc; i++)
     printf(1, "%s%s", argv[i], i + 1 < argc ? " " : "\n");
   exit();
 }

--- a/user/forktest.c
+++ b/user/forktest.c
@@ -1,40 +1,40 @@
 // Test that fork fails gracefully.
 // Tiny executable so that the limit can be filling the proc table.
 
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
 
 #define N 1000
 
-void printf(int fd, char *s, ...) { write(fd, s, strlen(s)); }
+void printf(int fd, char* s, ...) {
+  write(fd, s, strlen(s));
+}
 
 void forktest(void) {
   int n, pid;
 
   printf(1, "fork test\n");
 
-  for (n = 0; n < N; n++) {
+  for(n = 0; n < N; n++) {
     pid = fork();
-    if (pid < 0)
+    if(pid < 0)
       break;
-    if (pid == 0)
+    if(pid == 0)
       exit();
   }
 
-  if (n == N) {
+  if(n == N) {
     printf(1, "fork claimed to work N times!\n", N);
     exit();
   }
 
-  for (; n > 0; n--) {
-    if (wait() < 0) {
+  for(; n > 0; n--) {
+    if(wait() < 0) {
       printf(1, "wait stopped early\n");
       exit();
     }
   }
 
-  if (wait() != -1) {
+  if(wait() != -1) {
     printf(1, "wait got too many\n");
     exit();
   }

--- a/user/grep.c
+++ b/user/grep.c
@@ -1,55 +1,52 @@
 // Simple grep.  Only supports ^ . * $ operators.
-
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
 
 char buf[1024];
-int match(char *, char *);
+int match(char*, char*);
 
-void grep(char *pattern, int fd) {
+void grep(char* pattern, int fd) {
   int n, m;
   char *p, *q;
 
   m = 0;
-  while ((n = read(fd, buf + m, sizeof(buf) - m - 1)) > 0) {
+  while((n = read(fd, buf + m, sizeof(buf) - m - 1)) > 0) {
     m += n;
     buf[m] = '\0';
     p = buf;
-    while ((q = strchr(p, '\n')) != 0) {
+    while((q = strchr(p, '\n')) != 0) {
       *q = 0;
-      if (match(pattern, p)) {
+      if(match(pattern, p)) {
         *q = '\n';
         write(1, p, q + 1 - p);
       }
       p = q + 1;
     }
-    if (p == buf)
+    if(p == buf)
       m = 0;
-    if (m > 0) {
+    if(m > 0) {
       m -= p - buf;
       memmove(buf, p, m);
     }
   }
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   int fd, i;
-  char *pattern;
+  char* pattern;
 
-  if (argc <= 1) {
+  if(argc <= 1) {
     printf(2, "usage: grep pattern [file ...]\n");
     exit();
   }
   pattern = argv[1];
 
-  if (argc <= 2) {
+  if(argc <= 2) {
     grep(pattern, 0);
     exit();
   }
 
-  for (i = 2; i < argc; i++) {
-    if ((fd = open(argv[i], 0)) < 0) {
+  for(i = 2; i < argc; i++) {
+    if((fd = open(argv[i], 0)) < 0) {
       printf(1, "grep: cannot open %s\n", argv[i]);
       exit();
     }
@@ -62,37 +59,37 @@ int main(int argc, char *argv[]) {
 // Regexp matcher from Kernighan & Pike,
 // The Practice of Programming, Chapter 9.
 
-int matchhere(char *, char *);
-int matchstar(int, char *, char *);
+int matchhere(char*, char*);
+int matchstar(int, char*, char*);
 
-int match(char *re, char *text) {
-  if (re[0] == '^')
+int match(char* re, char* text) {
+  if(re[0] == '^')
     return matchhere(re + 1, text);
   do { // must look at empty string
-    if (matchhere(re, text))
+    if(matchhere(re, text))
       return 1;
-  } while (*text++ != '\0');
+  } while(*text++ != '\0');
   return 0;
 }
 
 // matchhere: search for re at beginning of text
-int matchhere(char *re, char *text) {
-  if (re[0] == '\0')
+int matchhere(char* re, char* text) {
+  if(re[0] == '\0')
     return 1;
-  if (re[1] == '*')
+  if(re[1] == '*')
     return matchstar(re[0], re + 2, text);
-  if (re[0] == '$' && re[1] == '\0')
+  if(re[0] == '$' && re[1] == '\0')
     return *text == '\0';
-  if (*text != '\0' && (re[0] == '.' || re[0] == *text))
+  if(*text != '\0' && (re[0] == '.' || re[0] == *text))
     return matchhere(re + 1, text + 1);
   return 0;
 }
 
 // matchstar: search for c*re at beginning of text
-int matchstar(int c, char *re, char *text) {
+int matchstar(int c, char* re, char* text) {
   do { // a * matches zero or more instances
-    if (matchhere(re, text))
+    if(matchhere(re, text))
       return 1;
-  } while (*text != '\0' && (*text++ == c || c == '.'));
+  } while(*text != '\0' && (*text++ == c || c == '.'));
   return 0;
 }

--- a/user/init.c
+++ b/user/init.c
@@ -1,36 +1,32 @@
 // init: The initial user-level program
-
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
-#include "kernel/fcntl.h"
 
-char *argv[] = {"sh", 0};
+char* argv[] = {"sh", 0};
 
 int main(void) {
   int pid, wpid;
   printf(1, "init: HERE\n");
 
-  if (open("console", O_RDWR) < 0) {
+  if(open("console", O_RDWR) < 0) {
     mknod("console", 1, 1);
     open("console", O_RDWR);
   }
   dup(0); // stdout
   dup(0); // stderr
 
-  for (;;) {
+  for(;;) {
     printf(1, "init: starting sh\n");
     pid = fork();
-    if (pid < 0) {
+    if(pid < 0) {
       printf(1, "init: fork failed\n");
       exit();
     }
-    if (pid == 0) {
+    if(pid == 0) {
       exec("sh", argv);
       printf(1, "init: exec sh failed\n");
       exit();
     }
-    while ((wpid = wait()) >= 0 && wpid != pid)
+    while((wpid = wait()) >= 0 && wpid != pid)
       printf(1, "zombie!\n");
   }
 }

--- a/user/initcode.S
+++ b/user/initcode.S
@@ -28,4 +28,3 @@ init:
 argv:
   .long init
   .long 0
-

--- a/user/kill.c
+++ b/user/kill.c
@@ -1,15 +1,11 @@
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
 
-int main(int argc, char **argv) {
-  int i;
-
-  if (argc < 2) {
+int main(int argc, char** argv) {
+  if(argc < 2) {
     printf(2, "usage: kill pid...\n");
     exit();
   }
-  for (i = 1; i < argc; i++)
+  for(int i = 1; i < argc; i++)
     kill(atoi(argv[i]));
   exit();
 }

--- a/user/ln.c
+++ b/user/ln.c
@@ -1,13 +1,11 @@
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
 
-int main(int argc, char *argv[]) {
-  if (argc != 3) {
+int main(int argc, char* argv[]) {
+  if(argc != 3) {
     printf(2, "Usage: ln old new\n");
     exit();
   }
-  if (link(argv[1], argv[2]) < 0)
+  if(link(argv[1], argv[2]) < 0)
     printf(2, "link %s %s: failed\n", argv[1], argv[2]);
   exit();
 }

--- a/user/ls.c
+++ b/user/ls.c
@@ -1,79 +1,76 @@
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
-#include "kernel/fs.h"
 
-char *fmtname(char *path) {
+char* fmtname(char* path) {
   static char buf[DIRSIZ + 1];
-  char *p;
+  char* p;
 
   // Find first character after last slash.
-  for (p = path + strlen(path); p >= path && *p != '/'; p--)
+  for(p = path + strlen(path); p >= path && *p != '/'; p--)
     ;
   p++;
 
   // Return blank-padded name.
-  if (strlen(p) >= DIRSIZ)
+  if(strlen(p) >= DIRSIZ)
     return p;
   memmove(buf, p, strlen(p));
   memset(buf + strlen(p), ' ', DIRSIZ - strlen(p));
   return buf;
 }
 
-void ls(char *path) {
+void ls(char* path) {
   char buf[512], *p;
   int fd;
   struct dirent de;
   struct stat st;
 
-  if ((fd = open(path, 0)) < 0) {
+  if((fd = open(path, 0)) < 0) {
     printf(2, "ls: cannot open %s\n", path);
     return;
   }
 
-  if (fstat(fd, &st) < 0) {
+  if(fstat(fd, &st) < 0) {
     printf(2, "ls: cannot stat %s\n", path);
     close(fd);
     return;
   }
 
-  switch (st.type) {
-  case T_FILE:
-    printf(1, "%s %d %d %d\n", fmtname(path), st.type, st.ino, st.size);
-    break;
-
-  case T_DIR:
-    if (strlen(path) + 1 + DIRSIZ + 1 > sizeof buf) {
-      printf(1, "ls: path too long\n");
+  switch(st.type) {
+    case T_FILE:
+      printf(1, "%s %d %d %d\n", fmtname(path), st.type, st.ino, st.size);
       break;
-    }
-    strcpy(buf, path);
-    p = buf + strlen(buf);
-    *p++ = '/';
-    while (read(fd, &de, sizeof(de)) == sizeof(de)) {
-      if (de.inum == 0)
-        continue;
-      memmove(p, de.name, DIRSIZ);
-      p[DIRSIZ] = 0;
-      if (stat(buf, &st) < 0) {
-        printf(1, "ls: cannot stat %s\n", buf);
-        continue;
+
+    case T_DIR:
+      if(strlen(path) + 1 + DIRSIZ + 1 > sizeof buf) {
+        printf(1, "ls: path too long\n");
+        break;
       }
-      printf(1, "%s %d %d %d\n", fmtname(buf), st.type, st.ino, st.size);
-    }
-    break;
+      strcpy(buf, path);
+      p = buf + strlen(buf);
+      *p++ = '/';
+      while(read(fd, &de, sizeof(de)) == sizeof(de)) {
+        if(de.inum == 0)
+          continue;
+        memmove(p, de.name, DIRSIZ);
+        p[DIRSIZ] = 0;
+        if(stat(buf, &st) < 0) {
+          printf(1, "ls: cannot stat %s\n", buf);
+          continue;
+        }
+        printf(1, "%s %d %d %d\n", fmtname(buf), st.type, st.ino, st.size);
+      }
+      break;
   }
   close(fd);
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   int i;
 
-  if (argc < 2) {
+  if(argc < 2) {
     ls(".");
     exit();
   }
-  for (i = 1; i < argc; i++)
+  for(i = 1; i < argc; i++)
     ls(argv[i]);
   exit();
 }

--- a/user/mkdir.c
+++ b/user/mkdir.c
@@ -1,17 +1,13 @@
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
 
-int main(int argc, char *argv[]) {
-  int i;
-
-  if (argc < 2) {
+int main(int argc, char* argv[]) {
+  if(argc < 2) {
     printf(2, "Usage: mkdir files...\n");
     exit();
   }
 
-  for (i = 1; i < argc; i++) {
-    if (mkdir(argv[i]) < 0) {
+  for(int i = 1; i < argc; i++) {
+    if(mkdir(argv[i]) < 0) {
       printf(2, "mkdir: %s failed to create\n", argv[i]);
       break;
     }

--- a/user/printf.c
+++ b/user/printf.c
@@ -1,8 +1,8 @@
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
 
-static void putc(int fd, char c) { write(fd, &c, 1); }
+static void putc(int fd, char c) {
+  write(fd, &c, 1);
+}
 
 static void printint(int fd, int xx, int base, int sgn) {
   static char digits[] = "0123456789ABCDEF";
@@ -11,7 +11,7 @@ static void printint(int fd, int xx, int base, int sgn) {
   uint x;
 
   neg = 0;
-  if (sgn && xx < 0) {
+  if(sgn && xx < 0) {
     neg = 1;
     x = -xx;
   } else {
@@ -21,50 +21,50 @@ static void printint(int fd, int xx, int base, int sgn) {
   i = 0;
   do {
     buf[i++] = digits[x % base];
-  } while ((x /= base) != 0);
-  if (neg)
+  } while((x /= base) != 0);
+  if(neg)
     buf[i++] = '-';
 
-  while (--i >= 0)
+  while(--i >= 0)
     putc(fd, buf[i]);
 }
 
 // Print to the given fd. Only understands %d, %x, %p, %s.
-void printf(int fd, char *fmt, ...) {
-  char *s;
+void printf(int fd, char* fmt, ...) {
+  char* s;
   int c, i, state;
-  uint *ap;
+  uint* ap;
 
   state = 0;
-  ap = (uint *)(void *)&fmt + 1;
-  for (i = 0; fmt[i]; i++) {
+  ap = (uint*) (void*) &fmt + 1;
+  for(i = 0; fmt[i]; i++) {
     c = fmt[i] & 0xff;
-    if (state == 0) {
-      if (c == '%') {
+    if(state == 0) {
+      if(c == '%') {
         state = '%';
       } else {
         putc(fd, c);
       }
-    } else if (state == '%') {
-      if (c == 'd') {
+    } else if(state == '%') {
+      if(c == 'd') {
         printint(fd, *ap, 10, 1);
         ap++;
-      } else if (c == 'x' || c == 'p') {
+      } else if(c == 'x' || c == 'p') {
         printint(fd, *ap, 16, 0);
         ap++;
-      } else if (c == 's') {
-        s = (char *)*ap;
+      } else if(c == 's') {
+        s = (char*) *ap;
         ap++;
-        if (s == 0)
+        if(s == 0)
           s = "(null)";
-        while (*s != 0) {
+        while(*s != 0) {
           putc(fd, *s);
           s++;
         }
-      } else if (c == 'c') {
+      } else if(c == 'c') {
         putc(fd, *ap);
         ap++;
-      } else if (c == '%') {
+      } else if(c == '%') {
         putc(fd, c);
       } else {
         // Unknown % sequence.  Print it to draw attention.

--- a/user/rm.c
+++ b/user/rm.c
@@ -1,17 +1,13 @@
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
 
-int main(int argc, char *argv[]) {
-  int i;
-
-  if (argc < 2) {
+int main(int argc, char* argv[]) {
+  if(argc < 2) {
     printf(2, "Usage: rm files...\n");
     exit();
   }
 
-  for (i = 1; i < argc; i++) {
-    if (unlink(argv[i]) < 0) {
+  for(int i = 1; i < argc; i++) {
+    if(unlink(argv[i]) < 0) {
       printf(2, "rm: %s failed to delete\n", argv[i]);
       break;
     }

--- a/user/sh.c
+++ b/user/sh.c
@@ -1,8 +1,5 @@
 // Shell.
-
-#include "kernel/types.h"
 #include "user.h"
-#include "kernel/fcntl.h"
 
 // Parsed command representation
 #define EXEC 1
@@ -19,115 +16,115 @@ struct cmd {
 
 struct execcmd {
   int type;
-  char *argv[MAXARGS];
-  char *eargv[MAXARGS];
+  char* argv[MAXARGS];
+  char* eargv[MAXARGS];
 };
 
 struct redircmd {
   int type;
-  struct cmd *cmd;
-  char *file;
-  char *efile;
+  struct cmd* cmd;
+  char* file;
+  char* efile;
   int mode;
   int fd;
 };
 
 struct pipecmd {
   int type;
-  struct cmd *left;
-  struct cmd *right;
+  struct cmd* left;
+  struct cmd* right;
 };
 
 struct listcmd {
   int type;
-  struct cmd *left;
-  struct cmd *right;
+  struct cmd* left;
+  struct cmd* right;
 };
 
 struct backcmd {
   int type;
-  struct cmd *cmd;
+  struct cmd* cmd;
 };
 
 int fork1(void); // Fork but panics on failure.
-void panic(char *);
-struct cmd *parsecmd(char *);
+void panic(char*);
+struct cmd* parsecmd(char*);
 
 // Execute cmd.  Never returns.
 #if __GNUC__ >= 12
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Winfinite-recursion"
 #endif
-void runcmd(struct cmd *cmd) {
+void runcmd(struct cmd* cmd) {
   int p[2];
-  struct backcmd *bcmd;
-  struct execcmd *ecmd;
-  struct listcmd *lcmd;
-  struct pipecmd *pcmd;
-  struct redircmd *rcmd;
+  struct backcmd* bcmd;
+  struct execcmd* ecmd;
+  struct listcmd* lcmd;
+  struct pipecmd* pcmd;
+  struct redircmd* rcmd;
 
-  if (cmd == 0)
+  if(cmd == 0)
     exit();
 
-  switch (cmd->type) {
-  default:
-    panic("runcmd");
+  switch(cmd->type) {
+    default:
+      panic("runcmd");
 
-  case EXEC:
-    ecmd = (struct execcmd *)cmd;
-    if (ecmd->argv[0] == 0)
-      exit();
-    exec(ecmd->argv[0], ecmd->argv);
-    printf(2, "exec %s failed\n", ecmd->argv[0]);
-    break;
+    case EXEC:
+      ecmd = (struct execcmd*) cmd;
+      if(ecmd->argv[0] == 0)
+        exit();
+      exec(ecmd->argv[0], ecmd->argv);
+      printf(2, "exec %s failed\n", ecmd->argv[0]);
+      break;
 
-  case REDIR:
-    rcmd = (struct redircmd *)cmd;
-    close(rcmd->fd);
-    if (open(rcmd->file, rcmd->mode) < 0) {
-      printf(2, "open %s failed\n", rcmd->file);
-      exit();
-    }
-    runcmd(rcmd->cmd);
-    break;
+    case REDIR:
+      rcmd = (struct redircmd*) cmd;
+      close(rcmd->fd);
+      if(open(rcmd->file, rcmd->mode) < 0) {
+        printf(2, "open %s failed\n", rcmd->file);
+        exit();
+      }
+      runcmd(rcmd->cmd);
+      break;
 
-  case LIST:
-    lcmd = (struct listcmd *)cmd;
-    if (fork1() == 0)
-      runcmd(lcmd->left);
-    wait();
-    runcmd(lcmd->right);
-    break;
+    case LIST:
+      lcmd = (struct listcmd*) cmd;
+      if(fork1() == 0)
+        runcmd(lcmd->left);
+      wait();
+      runcmd(lcmd->right);
+      break;
 
-  case PIPE:
-    pcmd = (struct pipecmd *)cmd;
-    if (pipe(p) < 0)
-      panic("pipe");
-    if (fork1() == 0) {
-      close(1);
-      dup(p[1]);
+    case PIPE:
+      pcmd = (struct pipecmd*) cmd;
+      if(pipe(p) < 0)
+        panic("pipe");
+      if(fork1() == 0) {
+        close(1);
+        dup(p[1]);
+        close(p[0]);
+        close(p[1]);
+        runcmd(pcmd->left);
+      }
+      if(fork1() == 0) {
+        close(0);
+        dup(p[0]);
+        close(p[0]);
+        close(p[1]);
+        runcmd(pcmd->right);
+      }
       close(p[0]);
       close(p[1]);
-      runcmd(pcmd->left);
-    }
-    if (fork1() == 0) {
-      close(0);
-      dup(p[0]);
-      close(p[0]);
-      close(p[1]);
-      runcmd(pcmd->right);
-    }
-    close(p[0]);
-    close(p[1]);
-    wait();
-    wait();
-    break;
+      wait();
+      wait();
+      break;
 
-  case BACK:
-    bcmd = (struct backcmd *)cmd;
-    if (fork1() == 0)
-      runcmd(bcmd->cmd);
-    break;
+    case BACK:
+      bcmd = (struct backcmd*) cmd;
+      if(fork1() == 0)
+        runcmd(bcmd->cmd);
+      break;
   }
   exit();
 }
@@ -135,11 +132,11 @@ void runcmd(struct cmd *cmd) {
 #pragma GCC diagnostic pop
 #endif
 
-int getcmd(char *buf, int nbuf) {
+int getcmd(char* buf, int nbuf) {
   printf(2, "$ ");
   memset(buf, 0, nbuf);
   gets(buf, nbuf);
-  if (buf[0] == 0) // EOF
+  if(buf[0] == 0) // EOF
     return -1;
   return 0;
 }
@@ -149,31 +146,31 @@ int main(void) {
   int fd;
 
   // Assumes three file descriptors open.
-  while ((fd = open("console", O_RDWR)) >= 0) {
-    if (fd >= 3) {
+  while((fd = open("console", O_RDWR)) >= 0) {
+    if(fd >= 3) {
       close(fd);
       break;
     }
   }
 
   // Read and run input commands.
-  while (getcmd(buf, sizeof(buf)) >= 0) {
-    if (buf[0] == 'c' && buf[1] == 'd' && buf[2] == ' ') {
+  while(getcmd(buf, sizeof(buf)) >= 0) {
+    if(buf[0] == 'c' && buf[1] == 'd' && buf[2] == ' ') {
       // Clumsy but will have to do for now.
       // Chdir has no effect on the parent if run in the child.
       buf[strlen(buf) - 1] = 0; // chop \n
-      if (chdir(buf + 3) < 0)
+      if(chdir(buf + 3) < 0)
         printf(2, "cannot cd %s\n", buf + 3);
       continue;
     }
-    if (fork1() == 0)
+    if(fork1() == 0)
       runcmd(parsecmd(buf));
     wait();
   }
   exit();
 }
 
-void panic(char *s) {
+void panic(char* s) {
   printf(2, "%s\n", s);
   exit();
 }
@@ -182,26 +179,25 @@ int fork1(void) {
   int pid;
 
   pid = fork();
-  if (pid == -1)
+  if(pid == -1)
     panic("fork");
   return pid;
 }
 
-// PAGEBREAK!
 // Constructors
 
-struct cmd *execcmd(void) {
-  struct execcmd *cmd;
+struct cmd* execcmd(void) {
+  struct execcmd* cmd;
 
   cmd = malloc(sizeof(*cmd));
   memset(cmd, 0, sizeof(*cmd));
   cmd->type = EXEC;
-  return (struct cmd *)cmd;
+  return (struct cmd*) cmd;
 }
 
-struct cmd *redircmd(struct cmd *subcmd, char *file, char *efile, int mode,
-                     int fd) {
-  struct redircmd *cmd;
+struct cmd* redircmd(struct cmd* subcmd, char* file, char* efile, int mode,
+    int fd) {
+  struct redircmd* cmd;
 
   cmd = malloc(sizeof(*cmd));
   memset(cmd, 0, sizeof(*cmd));
@@ -211,112 +207,112 @@ struct cmd *redircmd(struct cmd *subcmd, char *file, char *efile, int mode,
   cmd->efile = efile;
   cmd->mode = mode;
   cmd->fd = fd;
-  return (struct cmd *)cmd;
+  return (struct cmd*) cmd;
 }
 
-struct cmd *pipecmd(struct cmd *left, struct cmd *right) {
-  struct pipecmd *cmd;
+struct cmd* pipecmd(struct cmd* left, struct cmd* right) {
+  struct pipecmd* cmd;
 
   cmd = malloc(sizeof(*cmd));
   memset(cmd, 0, sizeof(*cmd));
   cmd->type = PIPE;
   cmd->left = left;
   cmd->right = right;
-  return (struct cmd *)cmd;
+  return (struct cmd*) cmd;
 }
 
-struct cmd *listcmd(struct cmd *left, struct cmd *right) {
-  struct listcmd *cmd;
+struct cmd* listcmd(struct cmd* left, struct cmd* right) {
+  struct listcmd* cmd;
 
   cmd = malloc(sizeof(*cmd));
   memset(cmd, 0, sizeof(*cmd));
   cmd->type = LIST;
   cmd->left = left;
   cmd->right = right;
-  return (struct cmd *)cmd;
+  return (struct cmd*) cmd;
 }
 
-struct cmd *backcmd(struct cmd *subcmd) {
-  struct backcmd *cmd;
+struct cmd* backcmd(struct cmd* subcmd) {
+  struct backcmd* cmd;
 
   cmd = malloc(sizeof(*cmd));
   memset(cmd, 0, sizeof(*cmd));
   cmd->type = BACK;
   cmd->cmd = subcmd;
-  return (struct cmd *)cmd;
+  return (struct cmd*) cmd;
 }
-// PAGEBREAK!
+
 // Parsing
 
 char whitespace[] = " \t\r\n\v";
 char symbols[] = "<|>&;()";
 
-int gettoken(char **ps, char *es, char **q, char **eq) {
-  char *s;
+int gettoken(char** ps, char* es, char** q, char** eq) {
+  char* s;
   int ret;
 
   s = *ps;
-  while (s < es && strchr(whitespace, *s))
+  while(s < es && strchr(whitespace, *s))
     s++;
-  if (q)
+  if(q)
     *q = s;
   ret = *s;
-  switch (*s) {
-  case 0:
-    break;
-  case '|':
-  case '(':
-  case ')':
-  case ';':
-  case '&':
-  case '<':
-    s++;
-    break;
-  case '>':
-    s++;
-    if (*s == '>') {
-      ret = '+';
+  switch(*s) {
+    case 0:
+      break;
+    case '|':
+    case '(':
+    case ')':
+    case ';':
+    case '&':
+    case '<':
       s++;
-    }
-    break;
-  default:
-    ret = 'a';
-    while (s < es && !strchr(whitespace, *s) && !strchr(symbols, *s))
+      break;
+    case '>':
       s++;
-    break;
+      if(*s == '>') {
+        ret = '+';
+        s++;
+      }
+      break;
+    default:
+      ret = 'a';
+      while(s < es && !strchr(whitespace, *s) && !strchr(symbols, *s))
+        s++;
+      break;
   }
-  if (eq)
+  if(eq)
     *eq = s;
 
-  while (s < es && strchr(whitespace, *s))
+  while(s < es && strchr(whitespace, *s))
     s++;
   *ps = s;
   return ret;
 }
 
-int peek(char **ps, char *es, char *toks) {
-  char *s;
+int peek(char** ps, char* es, char* toks) {
+  char* s;
 
   s = *ps;
-  while (s < es && strchr(whitespace, *s))
+  while(s < es && strchr(whitespace, *s))
     s++;
   *ps = s;
   return *s && strchr(toks, *s);
 }
 
-struct cmd *parseline(char **, char *);
-struct cmd *parsepipe(char **, char *);
-struct cmd *parseexec(char **, char *);
-struct cmd *nulterminate(struct cmd *);
+struct cmd* parseline(char**, char*);
+struct cmd* parsepipe(char**, char*);
+struct cmd* parseexec(char**, char*);
+struct cmd* nulterminate(struct cmd*);
 
-struct cmd *parsecmd(char *s) {
-  char *es;
-  struct cmd *cmd;
+struct cmd* parsecmd(char* s) {
+  char* es;
+  struct cmd* cmd;
 
   es = s + strlen(s);
   cmd = parseline(&s, es);
   peek(&s, es, "");
-  if (s != es) {
+  if(s != es) {
     printf(2, "leftovers: %s\n", s);
     panic("syntax");
   }
@@ -324,92 +320,92 @@ struct cmd *parsecmd(char *s) {
   return cmd;
 }
 
-struct cmd *parseline(char **ps, char *es) {
-  struct cmd *cmd;
+struct cmd* parseline(char** ps, char* es) {
+  struct cmd* cmd;
 
   cmd = parsepipe(ps, es);
-  while (peek(ps, es, "&")) {
+  while(peek(ps, es, "&")) {
     gettoken(ps, es, 0, 0);
     cmd = backcmd(cmd);
   }
-  if (peek(ps, es, ";")) {
+  if(peek(ps, es, ";")) {
     gettoken(ps, es, 0, 0);
     cmd = listcmd(cmd, parseline(ps, es));
   }
   return cmd;
 }
 
-struct cmd *parsepipe(char **ps, char *es) {
-  struct cmd *cmd;
+struct cmd* parsepipe(char** ps, char* es) {
+  struct cmd* cmd;
 
   cmd = parseexec(ps, es);
-  if (peek(ps, es, "|")) {
+  if(peek(ps, es, "|")) {
     gettoken(ps, es, 0, 0);
     cmd = pipecmd(cmd, parsepipe(ps, es));
   }
   return cmd;
 }
 
-struct cmd *parseredirs(struct cmd *cmd, char **ps, char *es) {
+struct cmd* parseredirs(struct cmd* cmd, char** ps, char* es) {
   int tok;
   char *q, *eq;
 
-  while (peek(ps, es, "<>")) {
+  while(peek(ps, es, "<>")) {
     tok = gettoken(ps, es, 0, 0);
-    if (gettoken(ps, es, &q, &eq) != 'a')
+    if(gettoken(ps, es, &q, &eq) != 'a')
       panic("missing file for redirection");
-    switch (tok) {
-    case '<':
-      cmd = redircmd(cmd, q, eq, O_RDONLY, 0);
-      break;
-    case '>':
-      cmd = redircmd(cmd, q, eq, O_WRONLY | O_CREATE, 1);
-      break;
-    case '+': // >>
-      cmd = redircmd(cmd, q, eq, O_WRONLY | O_CREATE, 1);
-      break;
+    switch(tok) {
+      case '<':
+        cmd = redircmd(cmd, q, eq, O_RDONLY, 0);
+        break;
+      case '>':
+        cmd = redircmd(cmd, q, eq, O_WRONLY | O_CREATE, 1);
+        break;
+      case '+': // >>
+        cmd = redircmd(cmd, q, eq, O_WRONLY | O_CREATE, 1);
+        break;
     }
   }
   return cmd;
 }
 
-struct cmd *parseblock(char **ps, char *es) {
-  struct cmd *cmd;
+struct cmd* parseblock(char** ps, char* es) {
+  struct cmd* cmd;
 
-  if (!peek(ps, es, "("))
+  if(!peek(ps, es, "("))
     panic("parseblock");
   gettoken(ps, es, 0, 0);
   cmd = parseline(ps, es);
-  if (!peek(ps, es, ")"))
+  if(!peek(ps, es, ")"))
     panic("syntax - missing )");
   gettoken(ps, es, 0, 0);
   cmd = parseredirs(cmd, ps, es);
   return cmd;
 }
 
-struct cmd *parseexec(char **ps, char *es) {
+struct cmd* parseexec(char** ps, char* es) {
   char *q, *eq;
   int tok, argc;
-  struct execcmd *cmd;
-  struct cmd *ret;
+  struct execcmd* cmd;
+  struct cmd* ret;
 
-  if (peek(ps, es, "("))
+  if(peek(ps, es, "("))
     return parseblock(ps, es);
 
   ret = execcmd();
-  cmd = (struct execcmd *)ret;
+  cmd = (struct execcmd*) ret;
 
   argc = 0;
   ret = parseredirs(ret, ps, es);
-  while (!peek(ps, es, "|)&;")) {
-    if ((tok = gettoken(ps, es, &q, &eq)) == 0)
+  while(!peek(ps, es, "|)&;")) {
+    if((tok = gettoken(ps, es, &q, &eq)) == 0)
       break;
-    if (tok != 'a')
+    if(tok != 'a')
       panic("syntax");
     cmd->argv[argc] = q;
     cmd->eargv[argc] = eq;
     argc++;
-    if (argc >= MAXARGS)
+    if(argc >= MAXARGS)
       panic("too many args");
     ret = parseredirs(ret, ps, es);
   }
@@ -419,46 +415,46 @@ struct cmd *parseexec(char **ps, char *es) {
 }
 
 // NUL-terminate all the counted strings.
-struct cmd *nulterminate(struct cmd *cmd) {
+struct cmd* nulterminate(struct cmd* cmd) {
   int i;
-  struct backcmd *bcmd;
-  struct execcmd *ecmd;
-  struct listcmd *lcmd;
-  struct pipecmd *pcmd;
-  struct redircmd *rcmd;
+  struct backcmd* bcmd;
+  struct execcmd* ecmd;
+  struct listcmd* lcmd;
+  struct pipecmd* pcmd;
+  struct redircmd* rcmd;
 
-  if (cmd == 0)
+  if(cmd == 0)
     return 0;
 
-  switch (cmd->type) {
-  case EXEC:
-    ecmd = (struct execcmd *)cmd;
-    for (i = 0; ecmd->argv[i]; i++)
-      *ecmd->eargv[i] = 0;
-    break;
+  switch(cmd->type) {
+    case EXEC:
+      ecmd = (struct execcmd*) cmd;
+      for(i = 0; ecmd->argv[i]; i++)
+        *ecmd->eargv[i] = 0;
+      break;
 
-  case REDIR:
-    rcmd = (struct redircmd *)cmd;
-    nulterminate(rcmd->cmd);
-    *rcmd->efile = 0;
-    break;
+    case REDIR:
+      rcmd = (struct redircmd*) cmd;
+      nulterminate(rcmd->cmd);
+      *rcmd->efile = 0;
+      break;
 
-  case PIPE:
-    pcmd = (struct pipecmd *)cmd;
-    nulterminate(pcmd->left);
-    nulterminate(pcmd->right);
-    break;
+    case PIPE:
+      pcmd = (struct pipecmd*) cmd;
+      nulterminate(pcmd->left);
+      nulterminate(pcmd->right);
+      break;
 
-  case LIST:
-    lcmd = (struct listcmd *)cmd;
-    nulterminate(lcmd->left);
-    nulterminate(lcmd->right);
-    break;
+    case LIST:
+      lcmd = (struct listcmd*) cmd;
+      nulterminate(lcmd->left);
+      nulterminate(lcmd->right);
+      break;
 
-  case BACK:
-    bcmd = (struct backcmd *)cmd;
-    nulterminate(bcmd->cmd);
-    break;
+    case BACK:
+      bcmd = (struct backcmd*) cmd;
+      nulterminate(bcmd->cmd);
+      break;
   }
   return cmd;
 }

--- a/user/stressfs.c
+++ b/user/stressfs.c
@@ -7,13 +7,9 @@
 //    for (i = 0; i < 40000; i++)
 //      asm volatile("");
 
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
-#include "kernel/fs.h"
-#include "kernel/fcntl.h"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   int fd, i;
   char path[] = "stressfs0";
   char data[512];
@@ -21,15 +17,15 @@ int main(int argc, char *argv[]) {
   printf(1, "stressfs starting\n");
   memset(data, 'a', sizeof(data));
 
-  for (i = 0; i < 4; i++)
-    if (fork() > 0)
+  for(i = 0; i < 4; i++)
+    if(fork() > 0)
       break;
 
   printf(1, "write %d\n", i);
 
   path[8] += i;
   fd = open(path, O_CREATE | O_RDWR);
-  for (i = 0; i < 20; i++)
+  for(i = 0; i < 20; i++)
     //    printf(fd, "%d\n", i);
     write(fd, data, sizeof(data));
   close(fd);
@@ -37,7 +33,7 @@ int main(int argc, char *argv[]) {
   printf(1, "read\n");
 
   fd = open(path, O_RDONLY);
-  for (i = 0; i < 20; i++)
+  for(i = 0; i < 20; i++)
     read(fd, data, sizeof(data));
   close(fd);
 

--- a/user/ulib.c
+++ b/user/ulib.c
@@ -1,87 +1,81 @@
-#include "kernel/types.h"
-#include "kernel/stat.h"
-#include "kernel/fcntl.h"
 #include "user.h"
-#include "kernel/x86.h"
 
-char *strcpy(char *s, char *t) {
-  char *os;
+char* strcpy(char* s, char* t) {
+  char* os;
 
   os = s;
-  while ((*s++ = *t++) != 0)
-    ;
+  while((*s++ = *t++) != 0) {}
   return os;
 }
 
-int strcmp(const char *p, const char *q) {
-  while (*p && *p == *q)
+int strcmp(const char* p, const char* q) {
+  while(*p && *p == *q)
     p++, q++;
-  return (uchar)*p - (uchar)*q;
+  return (uchar) *p - (uchar) *q;
 }
 
-uint strlen(char *s) {
+uint strlen(char* s) {
   int n;
 
-  for (n = 0; s[n]; n++)
-    ;
+  for(n = 0; s[n]; n++) {}
   return n;
 }
 
-void *memset(void *dst, int c, uint n) {
+void* memset(void* dst, int c, uint n) {
   stosb(dst, c, n);
   return dst;
 }
 
-char *strchr(const char *s, char c) {
-  for (; *s; s++)
-    if (*s == c)
-      return (char *)s;
+char* strchr(const char* s, char c) {
+  for(; *s; s++)
+    if(*s == c)
+      return (char*) s;
   return 0;
 }
 
-char *gets(char *buf, int max) {
+char* gets(char* buf, int max) {
   int i, cc;
   char c;
 
-  for (i = 0; i + 1 < max;) {
+  for(i = 0; i + 1 < max;) {
     cc = read(0, &c, 1);
-    if (cc < 1)
+    if(cc < 1)
       break;
     buf[i++] = c;
-    if (c == '\n' || c == '\r')
+    if(c == '\n' || c == '\r')
       break;
   }
   buf[i] = '\0';
   return buf;
 }
 
-int stat(char *n, struct stat *st) {
+int stat(char* n, struct stat* st) {
   int fd;
   int r;
 
   fd = open(n, O_RDONLY);
-  if (fd < 0)
+  if(fd < 0)
     return -1;
   r = fstat(fd, st);
   close(fd);
   return r;
 }
 
-int atoi(const char *s) {
+int atoi(const char* s) {
   int n;
 
   n = 0;
-  while ('0' <= *s && *s <= '9')
+  while('0' <= *s && *s <= '9')
     n = n * 10 + *s++ - '0';
   return n;
 }
 
-void *memmove(void *vdst, void *vsrc, int n) {
+void* memmove(void* vdst, void* vsrc, int n) {
   char *dst, *src;
 
   dst = vdst;
   src = vsrc;
-  while (n-- > 0)
+  while(n-- > 0)
     *dst++ = *src++;
   return vdst;
 }

--- a/user/umalloc.c
+++ b/user/umalloc.c
@@ -1,7 +1,4 @@
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
-#include "kernel/param.h"
 
 // Memory allocator by Kernighan and Ritchie,
 // The C programming Language, 2nd ed.  Section 8.7.
@@ -10,7 +7,7 @@ typedef long Align;
 
 union header {
   struct {
-    union header *ptr;
+    union header* ptr;
     uint size;
   } s;
   Align x;
@@ -19,21 +16,21 @@ union header {
 typedef union header Header;
 
 static Header base;
-static Header *freep;
+static Header* freep;
 
-void free(void *ap) {
+void free(void* ap) {
   Header *bp, *p;
 
-  bp = (Header *)ap - 1;
-  for (p = freep; !(bp > p && bp < p->s.ptr); p = p->s.ptr)
-    if (p >= p->s.ptr && (bp > p || bp < p->s.ptr))
+  bp = (Header*) ap - 1;
+  for(p = freep; !(bp > p && bp < p->s.ptr); p = p->s.ptr)
+    if(p >= p->s.ptr && (bp > p || bp < p->s.ptr))
       break;
-  if (bp + bp->s.size == p->s.ptr) {
+  if(bp + bp->s.size == p->s.ptr) {
     bp->s.size += p->s.ptr->s.size;
     bp->s.ptr = p->s.ptr->s.ptr;
   } else
     bp->s.ptr = p->s.ptr;
-  if (p + p->s.size == bp) {
+  if(p + p->s.size == bp) {
     p->s.size += bp->s.size;
     p->s.ptr = bp->s.ptr;
   } else
@@ -41,30 +38,30 @@ void free(void *ap) {
   freep = p;
 }
 
-static Header *morecore(uint nu) {
-  char *p;
-  Header *hp;
+static Header* morecore(uint nu) {
+  char* p;
+  Header* hp;
 
-  if (nu < 4096)
+  if(nu < 4096)
     nu = 4096;
   p = sbrk(nu * sizeof(Header));
-  if (p == (char *)-1)
+  if(p == (char*) -1)
     return 0;
-  hp = (Header *)p;
+  hp = (Header*) p;
   hp->s.size = nu;
-  free((void *)(hp + 1));
+  free((void*) (hp + 1));
   return freep;
 }
 
-void *realloc(void *ap, uint nbytes) {
-  Header *bp = (Header *)ap - 1;
+void* realloc(void* ap, uint nbytes) {
+  Header* bp = (Header*) ap - 1;
   uint nunits = (nbytes + sizeof(Header) - 1) / sizeof(Header) + 1;
 
-  if (bp->s.size >= nunits)
+  if(bp->s.size >= nunits)
     return ap;
 
-  void *np = malloc(nbytes);
-  if (!np)
+  void* np = malloc(nbytes);
+  if(!np)
     return 0;
 
   memmove(np, ap, (bp->s.size - 1) * sizeof(Header));
@@ -72,18 +69,18 @@ void *realloc(void *ap, uint nbytes) {
   return np;
 }
 
-void *malloc(uint nbytes) {
+void* malloc(uint nbytes) {
   Header *p, *prevp;
   uint nunits;
 
   nunits = (nbytes + sizeof(Header) - 1) / sizeof(Header) + 1;
-  if ((prevp = freep) == 0) {
+  if((prevp = freep) == 0) {
     base.s.ptr = freep = prevp = &base;
     base.s.size = 0;
   }
-  for (p = prevp->s.ptr;; prevp = p, p = p->s.ptr) {
-    if (p->s.size >= nunits) {
-      if (p->s.size == nunits)
+  for(p = prevp->s.ptr;; prevp = p, p = p->s.ptr) {
+    if(p->s.size >= nunits) {
+      if(p->s.size == nunits)
         prevp->s.ptr = p->s.ptr;
       else {
         p->s.size -= nunits;
@@ -91,10 +88,10 @@ void *malloc(uint nbytes) {
         p->s.size = nunits;
       }
       freep = prevp;
-      return (void *)(p + 1);
+      return (void*) (p + 1);
     }
-    if (p == freep)
-      if ((p = morecore(nunits)) == 0)
+    if(p == freep)
+      if((p = morecore(nunits)) == 0)
         return 0;
   }
 }

--- a/user/user.h
+++ b/user/user.h
@@ -1,47 +1,49 @@
 #ifndef XV6_USER_H
 #define XV6_USER_H
 
-#include "kernel/types.h"
-#include "kernel/fcntl.h"
-#include "kernel/stat.h"
 #include "kernel/date.h"
+#include "kernel/fcntl.h"
+#include "kernel/fs.h"
+#include "kernel/stat.h"
+#include "kernel/types.h"
+#include "kernel/x86.h"
 
 // system calls
 int fork(void);
 int exit(void) __attribute__((noreturn));
 int wait(void);
-int pipe(int *);
-int write(int, void *, int);
-int read(int, void *, int);
+int pipe(int*);
+int write(int, void*, int);
+int read(int, void*, int);
 int close(int);
 int kill(int);
-int exec(char *, char **);
-int open(char *, int);
-int mknod(char *, short, short);
-int unlink(char *);
-int fstat(int fd, struct stat *);
-int link(char *, char *);
-int mkdir(char *);
-int chdir(char *);
+int exec(char*, char**);
+int open(char*, int);
+int mknod(char*, short, short);
+int unlink(char*);
+int fstat(int fd, struct stat*);
+int link(char*, char*);
+int mkdir(char*);
+int chdir(char*);
 int dup(int);
 int getpid(void);
-char *sbrk(int);
+char* sbrk(int);
 int sleep(int);
 int uptime(void);
 
 // ulib.c
-int stat(char *, struct stat *);
-char *strcpy(char *, char *);
-void *memmove(void *, void *, int);
-char *strchr(const char *, char c);
-int strcmp(const char *, const char *);
-void printf(int, char *, ...);
-char *gets(char *, int max);
-uint strlen(char *);
-void *memset(void *, int, uint);
-void *malloc(uint);
-void free(void *);
-void *realloc(void *, uint);
-int atoi(const char *);
+int stat(char*, struct stat*);
+char* strcpy(char*, char*);
+void* memmove(void*, void*, int);
+char* strchr(const char*, char c);
+int strcmp(const char*, const char*);
+void printf(int, char*, ...);
+char* gets(char*, int max);
+uint strlen(char*);
+void* memset(void*, int, uint);
+void* malloc(uint);
+void free(void*);
+void* realloc(void*, uint);
+int atoi(const char*);
 
 #endif // XV6_USER_H

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -1,35 +1,31 @@
+#include "kernel/memlayout.h"
 #include "kernel/param.h"
-#include "kernel/types.h"
-#include "kernel/stat.h"
-#include "user.h"
-#include "kernel/fs.h"
-#include "kernel/fcntl.h"
 #include "kernel/syscall.h"
 #include "kernel/traps.h"
-#include "kernel/memlayout.h"
+#include "user.h"
 
 char buf[8192];
 char name[3];
-char *echoargv[] = {"echo", "ALL", "TESTS", "PASSED", 0};
+char* echoargv[] = {"echo", "ALL", "TESTS", "PASSED", 0};
 int stdout = 1;
 
 // does chdir() call iput(p->cwd) in a transaction?
 void iputtest(void) {
   printf(stdout, "iput test\n");
 
-  if (mkdir("iputdir") < 0) {
+  if(mkdir("iputdir") < 0) {
     printf(stdout, "mkdir failed\n");
     exit();
   }
-  if (chdir("iputdir") < 0) {
+  if(chdir("iputdir") < 0) {
     printf(stdout, "chdir iputdir failed\n");
     exit();
   }
-  if (unlink("../iputdir") < 0) {
+  if(unlink("../iputdir") < 0) {
     printf(stdout, "unlink ../iputdir failed\n");
     exit();
   }
-  if (chdir("/") < 0) {
+  if(chdir("/") < 0) {
     printf(stdout, "chdir / failed\n");
     exit();
   }
@@ -43,20 +39,20 @@ void exitiputtest(void) {
   printf(stdout, "exitiput test\n");
 
   pid = fork();
-  if (pid < 0) {
+  if(pid < 0) {
     printf(stdout, "fork failed\n");
     exit();
   }
-  if (pid == 0) {
-    if (mkdir("iputdir") < 0) {
+  if(pid == 0) {
+    if(mkdir("iputdir") < 0) {
       printf(stdout, "mkdir failed\n");
       exit();
     }
-    if (chdir("iputdir") < 0) {
+    if(chdir("iputdir") < 0) {
       printf(stdout, "child chdir failed\n");
       exit();
     }
-    if (unlink("../iputdir") < 0) {
+    if(unlink("../iputdir") < 0) {
       printf(stdout, "unlink ../iputdir failed\n");
       exit();
     }
@@ -81,25 +77,25 @@ void openiputtest(void) {
   int pid;
 
   printf(stdout, "openiput test\n");
-  if (mkdir("oidir") < 0) {
+  if(mkdir("oidir") < 0) {
     printf(stdout, "mkdir oidir failed\n");
     exit();
   }
   pid = fork();
-  if (pid < 0) {
+  if(pid < 0) {
     printf(stdout, "fork failed\n");
     exit();
   }
-  if (pid == 0) {
+  if(pid == 0) {
     int fd = open("oidir", O_RDWR);
-    if (fd >= 0) {
+    if(fd >= 0) {
       printf(stdout, "open directory for write succeeded\n");
       exit();
     }
     exit();
   }
   sleep(1);
-  if (unlink("oidir") != 0) {
+  if(unlink("oidir") != 0) {
     printf(stdout, "unlink failed\n");
     exit();
   }
@@ -114,13 +110,13 @@ void opentest(void) {
 
   printf(stdout, "open test\n");
   fd = open("echo", 0);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(stdout, "open echo failed!\n");
     exit();
   }
   close(fd);
   fd = open("doesnotexist", 0);
-  if (fd >= 0) {
+  if(fd >= 0) {
     printf(stdout, "open doesnotexist succeeded!\n");
     exit();
   }
@@ -133,18 +129,18 @@ void writetest(void) {
 
   printf(stdout, "small file test\n");
   fd = open("small", O_CREATE | O_RDWR);
-  if (fd >= 0) {
+  if(fd >= 0) {
     printf(stdout, "creat small succeeded; ok\n");
   } else {
     printf(stdout, "error: creat small failed!\n");
     exit();
   }
-  for (i = 0; i < 100; i++) {
-    if (write(fd, "aaaaaaaaaa", 10) != 10) {
+  for(i = 0; i < 100; i++) {
+    if(write(fd, "aaaaaaaaaa", 10) != 10) {
       printf(stdout, "error: write aa %d new file failed\n", i);
       exit();
     }
-    if (write(fd, "bbbbbbbbbb", 10) != 10) {
+    if(write(fd, "bbbbbbbbbb", 10) != 10) {
       printf(stdout, "error: write bb %d new file failed\n", i);
       exit();
     }
@@ -152,14 +148,14 @@ void writetest(void) {
   printf(stdout, "writes ok\n");
   close(fd);
   fd = open("small", O_RDONLY);
-  if (fd >= 0) {
+  if(fd >= 0) {
     printf(stdout, "open small succeeded ok\n");
   } else {
     printf(stdout, "error: open small failed!\n");
     exit();
   }
   i = read(fd, buf, 2000);
-  if (i == 2000) {
+  if(i == 2000) {
     printf(stdout, "read succeeded ok\n");
   } else {
     printf(stdout, "read failed\n");
@@ -167,7 +163,7 @@ void writetest(void) {
   }
   close(fd);
 
-  if (unlink("small") < 0) {
+  if(unlink("small") < 0) {
     printf(stdout, "unlink small failed\n");
     exit();
   }
@@ -180,14 +176,14 @@ void writetest1(void) {
   printf(stdout, "big files test\n");
 
   fd = open("big", O_CREATE | O_RDWR);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(stdout, "error: creat big failed!\n");
     exit();
   }
 
-  for (i = 0; i < MAXFILE; i++) {
-    ((int *)buf)[0] = i;
-    if (write(fd, buf, 512) != 512) {
+  for(i = 0; i < MAXFILE; i++) {
+    ((int*) buf)[0] = i;
+    if(write(fd, buf, 512) != 512) {
       printf(stdout, "error: write big file failed\n", i);
       exit();
     }
@@ -196,32 +192,32 @@ void writetest1(void) {
   close(fd);
 
   fd = open("big", O_RDONLY);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(stdout, "error: open big failed!\n");
     exit();
   }
 
   n = 0;
-  for (;;) {
+  for(;;) {
     i = read(fd, buf, 512);
-    if (i == 0) {
-      if (n == MAXFILE - 1) {
+    if(i == 0) {
+      if(n == MAXFILE - 1) {
         printf(stdout, "read only %d blocks from big", n);
         exit();
       }
       break;
-    } else if (i != 512) {
+    } else if(i != 512) {
       printf(stdout, "read failed %d\n", i);
       exit();
     }
-    if (((int *)buf)[0] != n) {
-      printf(stdout, "read content of block %d is %d\n", n, ((int *)buf)[0]);
+    if(((int*) buf)[0] != n) {
+      printf(stdout, "read content of block %d is %d\n", n, ((int*) buf)[0]);
       exit();
     }
     n++;
   }
   close(fd);
-  if (unlink("big") < 0) {
+  if(unlink("big") < 0) {
     printf(stdout, "unlink big failed\n");
     exit();
   }
@@ -235,14 +231,14 @@ void createtest(void) {
 
   name[0] = 'a';
   name[2] = '\0';
-  for (i = 0; i < 52; i++) {
+  for(i = 0; i < 52; i++) {
     name[1] = '0' + i;
     fd = open(name, O_CREATE | O_RDWR);
     close(fd);
   }
   name[0] = 'a';
   name[2] = '\0';
-  for (i = 0; i < 52; i++) {
+  for(i = 0; i < 52; i++) {
     name[1] = '0' + i;
     unlink(name);
   }
@@ -252,22 +248,22 @@ void createtest(void) {
 void dirtest(void) {
   printf(stdout, "mkdir test\n");
 
-  if (mkdir("dir0") < 0) {
+  if(mkdir("dir0") < 0) {
     printf(stdout, "mkdir failed\n");
     exit();
   }
 
-  if (chdir("dir0") < 0) {
+  if(chdir("dir0") < 0) {
     printf(stdout, "chdir dir0 failed\n");
     exit();
   }
 
-  if (chdir("..") < 0) {
+  if(chdir("..") < 0) {
     printf(stdout, "chdir .. failed\n");
     exit();
   }
 
-  if (unlink("dir0") < 0) {
+  if(unlink("dir0") < 0) {
     printf(stdout, "unlink dir0 failed\n");
     exit();
   }
@@ -276,7 +272,7 @@ void dirtest(void) {
 
 void exectest(void) {
   printf(stdout, "exec test\n");
-  if (exec("echo", echoargv) < 0) {
+  if(exec("echo", echoargv) < 0) {
     printf(stdout, "exec echo failed\n");
     exit();
   }
@@ -288,40 +284,40 @@ void pipe1(void) {
   int fds[2], pid;
   int seq, i, n, cc, total;
 
-  if (pipe(fds) != 0) {
+  if(pipe(fds) != 0) {
     printf(1, "pipe() failed\n");
     exit();
   }
   pid = fork();
   seq = 0;
-  if (pid == 0) {
+  if(pid == 0) {
     close(fds[0]);
-    for (n = 0; n < 5; n++) {
-      for (i = 0; i < 1033; i++)
+    for(n = 0; n < 5; n++) {
+      for(i = 0; i < 1033; i++)
         buf[i] = seq++;
-      if (write(fds[1], buf, 1033) != 1033) {
+      if(write(fds[1], buf, 1033) != 1033) {
         printf(1, "pipe1 oops 1\n");
         exit();
       }
     }
     exit();
-  } else if (pid > 0) {
+  } else if(pid > 0) {
     close(fds[1]);
     total = 0;
     cc = 1;
-    while ((n = read(fds[0], buf, cc)) > 0) {
-      for (i = 0; i < n; i++) {
-        if ((buf[i] & 0xff) != (seq++ & 0xff)) {
+    while((n = read(fds[0], buf, cc)) > 0) {
+      for(i = 0; i < n; i++) {
+        if((buf[i] & 0xff) != (seq++ & 0xff)) {
           printf(1, "pipe1 oops 2\n");
           return;
         }
       }
       total += n;
       cc = cc * 2;
-      if (cc > sizeof(buf))
+      if(cc > sizeof(buf))
         cc = sizeof(buf);
     }
-    if (total != 5 * 1033) {
+    if(total != 5 * 1033) {
       printf(1, "pipe1 oops 3 total %d\n", total);
       exit();
     }
@@ -341,28 +337,28 @@ void preempt(void) {
 
   printf(1, "preempt: ");
   pid1 = fork();
-  if (pid1 == 0)
-    for (;;)
+  if(pid1 == 0)
+    for(;;)
       ;
 
   pid2 = fork();
-  if (pid2 == 0)
-    for (;;)
+  if(pid2 == 0)
+    for(;;)
       ;
 
   pipe(pfds);
   pid3 = fork();
-  if (pid3 == 0) {
+  if(pid3 == 0) {
     close(pfds[0]);
-    if (write(pfds[1], "x", 1) != 1)
+    if(write(pfds[1], "x", 1) != 1)
       printf(1, "preempt write error");
     close(pfds[1]);
-    for (;;)
+    for(;;)
       ;
   }
 
   close(pfds[1]);
-  if (read(pfds[0], buf, sizeof(buf)) != 1) {
+  if(read(pfds[0], buf, sizeof(buf)) != 1) {
     printf(1, "preempt read error");
     return;
   }
@@ -382,14 +378,14 @@ void preempt(void) {
 void exitwait(void) {
   int i, pid;
 
-  for (i = 0; i < 100; i++) {
+  for(i = 0; i < 100; i++) {
     pid = fork();
-    if (pid < 0) {
+    if(pid < 0) {
       printf(1, "fork failed\n");
       return;
     }
-    if (pid) {
-      if (wait() != pid) {
+    if(pid) {
+      if(wait() != pid) {
         printf(1, "wait wrong pid\n");
         return;
       }
@@ -406,19 +402,19 @@ void mem(void) {
 
   printf(1, "mem test\n");
   ppid = getpid();
-  if ((pid = fork()) == 0) {
+  if((pid = fork()) == 0) {
     m1 = 0;
-    while ((m2 = malloc(10001)) != 0) {
-      *(char **)m2 = m1;
+    while((m2 = malloc(10001)) != 0) {
+      *(char**) m2 = m1;
       m1 = m2;
     }
-    while (m1) {
-      m2 = *(char **)m1;
+    while(m1) {
+      m2 = *(char**) m1;
       free(m1);
       m1 = m2;
     }
     m1 = malloc(1024 * 20);
-    if (m1 == 0) {
+    if(m1 == 0) {
       printf(1, "couldn't allocate mem?!!\n");
       kill(ppid);
       exit();
@@ -443,40 +439,40 @@ void sharedfd(void) {
 
   unlink("sharedfd");
   fd = open("sharedfd", O_CREATE | O_RDWR);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "fstests: cannot open sharedfd for writing");
     return;
   }
   pid = fork();
   memset(buf, pid == 0 ? 'c' : 'p', sizeof(buf));
-  for (i = 0; i < 1000; i++) {
-    if (write(fd, buf, sizeof(buf)) != sizeof(buf)) {
+  for(i = 0; i < 1000; i++) {
+    if(write(fd, buf, sizeof(buf)) != sizeof(buf)) {
       printf(1, "fstests: write sharedfd failed\n");
       break;
     }
   }
-  if (pid == 0)
+  if(pid == 0)
     exit();
   else
     wait();
   close(fd);
   fd = open("sharedfd", 0);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "fstests: cannot open sharedfd for reading\n");
     return;
   }
   nc = np = 0;
-  while ((n = read(fd, buf, sizeof(buf))) > 0) {
-    for (i = 0; i < sizeof(buf); i++) {
-      if (buf[i] == 'c')
+  while((n = read(fd, buf, sizeof(buf))) > 0) {
+    for(i = 0; i < sizeof(buf); i++) {
+      if(buf[i] == 'c')
         nc++;
-      if (buf[i] == 'p')
+      if(buf[i] == 'p')
         np++;
     }
   }
   close(fd);
   unlink("sharedfd");
-  if (nc == 10000 && np == 10000) {
+  if(nc == 10000 && np == 10000) {
     printf(1, "sharedfd ok\n");
   } else {
     printf(1, "sharedfd oops %d %d\n", nc, np);
@@ -488,31 +484,31 @@ void sharedfd(void) {
 // time, to test block allocation.
 void fourfiles(void) {
   int fd, pid, i, j, n, total, pi;
-  char *names[] = {"f0", "f1", "f2", "f3"};
-  char *fname;
+  char* names[] = {"f0", "f1", "f2", "f3"};
+  char* fname;
 
   printf(1, "fourfiles test\n");
 
-  for (pi = 0; pi < 4; pi++) {
+  for(pi = 0; pi < 4; pi++) {
     fname = names[pi];
     unlink(fname);
 
     pid = fork();
-    if (pid < 0) {
+    if(pid < 0) {
       printf(1, "fork failed\n");
       exit();
     }
 
-    if (pid == 0) {
+    if(pid == 0) {
       fd = open(fname, O_CREATE | O_RDWR);
-      if (fd < 0) {
+      if(fd < 0) {
         printf(1, "create failed\n");
         exit();
       }
 
       memset(buf, '0' + pi, 512);
-      for (i = 0; i < 12; i++) {
-        if ((n = write(fd, buf, 500)) != 500) {
+      for(i = 0; i < 12; i++) {
+        if((n = write(fd, buf, 500)) != 500) {
           printf(1, "write failed %d\n", n);
           exit();
         }
@@ -521,17 +517,17 @@ void fourfiles(void) {
     }
   }
 
-  for (pi = 0; pi < 4; pi++) {
+  for(pi = 0; pi < 4; pi++) {
     wait();
   }
 
-  for (i = 0; i < 2; i++) {
+  for(i = 0; i < 2; i++) {
     fname = names[i];
     fd = open(fname, 0);
     total = 0;
-    while ((n = read(fd, buf, sizeof(buf))) > 0) {
-      for (j = 0; j < n; j++) {
-        if (buf[j] != '0' + i) {
+    while((n = read(fd, buf, sizeof(buf))) > 0) {
+      for(j = 0; j < n; j++) {
+        if(buf[j] != '0' + i) {
           printf(1, "wrong char\n");
           exit();
         }
@@ -539,7 +535,7 @@ void fourfiles(void) {
       total += n;
     }
     close(fd);
-    if (total != 12 * 500) {
+    if(total != 12 * 500) {
       printf(1, "wrong length %d\n", total);
       exit();
     }
@@ -557,27 +553,27 @@ void createdelete(void) {
 
   printf(1, "createdelete test\n");
 
-  for (pi = 0; pi < 4; pi++) {
+  for(pi = 0; pi < 4; pi++) {
     pid = fork();
-    if (pid < 0) {
+    if(pid < 0) {
       printf(1, "fork failed\n");
       exit();
     }
 
-    if (pid == 0) {
+    if(pid == 0) {
       name[0] = 'p' + pi;
       name[2] = '\0';
-      for (i = 0; i < N; i++) {
+      for(i = 0; i < N; i++) {
         name[1] = '0' + i;
         fd = open(name, O_CREATE | O_RDWR);
-        if (fd < 0) {
+        if(fd < 0) {
           printf(1, "create failed\n");
           exit();
         }
         close(fd);
-        if (i > 0 && (i % 2) == 0) {
+        if(i > 0 && (i % 2) == 0) {
           name[1] = '0' + (i / 2);
-          if (unlink(name) < 0) {
+          if(unlink(name) < 0) {
             printf(1, "unlink failed\n");
             exit();
           }
@@ -587,30 +583,30 @@ void createdelete(void) {
     }
   }
 
-  for (pi = 0; pi < 4; pi++) {
+  for(pi = 0; pi < 4; pi++) {
     wait();
   }
 
   name[0] = name[1] = name[2] = 0;
-  for (i = 0; i < N; i++) {
-    for (pi = 0; pi < 4; pi++) {
+  for(i = 0; i < N; i++) {
+    for(pi = 0; pi < 4; pi++) {
       name[0] = 'p' + pi;
       name[1] = '0' + i;
       fd = open(name, 0);
-      if ((i == 0 || i >= N / 2) && fd < 0) {
+      if((i == 0 || i >= N / 2) && fd < 0) {
         printf(1, "oops createdelete %s didn't exist\n", name);
         exit();
-      } else if ((i >= 1 && i < N / 2) && fd >= 0) {
+      } else if((i >= 1 && i < N / 2) && fd >= 0) {
         printf(1, "oops createdelete %s did exist\n", name);
         exit();
       }
-      if (fd >= 0)
+      if(fd >= 0)
         close(fd);
     }
   }
 
-  for (i = 0; i < N; i++) {
-    for (pi = 0; pi < 4; pi++) {
+  for(i = 0; i < N; i++) {
+    for(pi = 0; pi < 4; pi++) {
       name[0] = 'p' + i;
       name[1] = '0' + i;
       unlink(name);
@@ -626,7 +622,7 @@ void unlinkread(void) {
 
   printf(1, "unlinkread test\n");
   fd = open("unlinkread", O_CREATE | O_RDWR);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "create unlinkread failed\n");
     exit();
   }
@@ -634,11 +630,11 @@ void unlinkread(void) {
   close(fd);
 
   fd = open("unlinkread", O_RDWR);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "open unlinkread failed\n");
     exit();
   }
-  if (unlink("unlinkread") != 0) {
+  if(unlink("unlinkread") != 0) {
     printf(1, "unlink unlinkread failed\n");
     exit();
   }
@@ -647,15 +643,15 @@ void unlinkread(void) {
   write(fd1, "yyy", 3);
   close(fd1);
 
-  if (read(fd, buf, sizeof(buf)) != 5) {
+  if(read(fd, buf, sizeof(buf)) != 5) {
     printf(1, "unlinkread read failed");
     exit();
   }
-  if (buf[0] != 'h') {
+  if(buf[0] != 'h') {
     printf(1, "unlinkread wrong data\n");
     exit();
   }
-  if (write(fd, buf, 10) != 10) {
+  if(write(fd, buf, 10) != 10) {
     printf(1, "unlinkread write failed\n");
     exit();
   }
@@ -673,50 +669,50 @@ void linktest(void) {
   unlink("lf2");
 
   fd = open("lf1", O_CREATE | O_RDWR);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "create lf1 failed\n");
     exit();
   }
-  if (write(fd, "hello", 5) != 5) {
+  if(write(fd, "hello", 5) != 5) {
     printf(1, "write lf1 failed\n");
     exit();
   }
   close(fd);
 
-  if (link("lf1", "lf2") < 0) {
+  if(link("lf1", "lf2") < 0) {
     printf(1, "link lf1 lf2 failed\n");
     exit();
   }
   unlink("lf1");
 
-  if (open("lf1", 0) >= 0) {
+  if(open("lf1", 0) >= 0) {
     printf(1, "unlinked lf1 but it is still there!\n");
     exit();
   }
 
   fd = open("lf2", 0);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "open lf2 failed\n");
     exit();
   }
-  if (read(fd, buf, sizeof(buf)) != 5) {
+  if(read(fd, buf, sizeof(buf)) != 5) {
     printf(1, "read lf2 failed\n");
     exit();
   }
   close(fd);
 
-  if (link("lf2", "lf2") >= 0) {
+  if(link("lf2", "lf2") >= 0) {
     printf(1, "link lf2 lf2 succeeded! oops\n");
     exit();
   }
 
   unlink("lf2");
-  if (link("lf2", "lf1") >= 0) {
+  if(link("lf2", "lf1") >= 0) {
     printf(1, "link non-existant succeeded! oops\n");
     exit();
   }
 
-  if (link(".", "lf1") >= 0) {
+  if(link(".", "lf1") >= 0) {
     printf(1, "link . lf1 succeeded! oops\n");
     exit();
   }
@@ -737,23 +733,23 @@ void concreate(void) {
   printf(1, "concreate test\n");
   file[0] = 'C';
   file[2] = '\0';
-  for (i = 0; i < 40; i++) {
+  for(i = 0; i < 40; i++) {
     file[1] = '0' + i;
     unlink(file);
     pid = fork();
-    if (pid && (i % 3) == 1) {
+    if(pid && (i % 3) == 1) {
       link("C0", file);
-    } else if (pid == 0 && (i % 5) == 1) {
+    } else if(pid == 0 && (i % 5) == 1) {
       link("C0", file);
     } else {
       fd = open(file, O_CREATE | O_RDWR);
-      if (fd < 0) {
+      if(fd < 0) {
         printf(1, "concreate create %s failed\n", file);
         exit();
       }
       close(fd);
     }
-    if (pid == 0)
+    if(pid == 0)
       exit();
     else
       wait();
@@ -762,16 +758,16 @@ void concreate(void) {
   memset(fa, 0, sizeof(fa));
   fd = open(".", 0);
   n = 0;
-  while (read(fd, &de, sizeof(de)) > 0) {
-    if (de.inum == 0)
+  while(read(fd, &de, sizeof(de)) > 0) {
+    if(de.inum == 0)
       continue;
-    if (de.name[0] == 'C' && de.name[2] == '\0') {
+    if(de.name[0] == 'C' && de.name[2] == '\0') {
       i = de.name[1] - '0';
-      if (i < 0 || i >= sizeof(fa)) {
+      if(i < 0 || i >= sizeof(fa)) {
         printf(1, "concreate weird file %s\n", de.name);
         exit();
       }
-      if (fa[i]) {
+      if(fa[i]) {
         printf(1, "concreate duplicate file %s\n", de.name);
         exit();
       }
@@ -781,19 +777,19 @@ void concreate(void) {
   }
   close(fd);
 
-  if (n != 40) {
+  if(n != 40) {
     printf(1, "concreate not enough files in directory listing\n");
     exit();
   }
 
-  for (i = 0; i < 40; i++) {
+  for(i = 0; i < 40; i++) {
     file[1] = '0' + i;
     pid = fork();
-    if (pid < 0) {
+    if(pid < 0) {
       printf(1, "fork failed\n");
       exit();
     }
-    if (((i % 3) == 0 && pid == 0) || ((i % 3) == 1 && pid != 0)) {
+    if(((i % 3) == 0 && pid == 0) || ((i % 3) == 1 && pid != 0)) {
       close(open(file, 0));
       close(open(file, 0));
       close(open(file, 0));
@@ -804,7 +800,7 @@ void concreate(void) {
       unlink(file);
       unlink(file);
     }
-    if (pid == 0)
+    if(pid == 0)
       exit();
     else
       wait();
@@ -822,24 +818,24 @@ void linkunlink() {
 
   unlink("x");
   pid = fork();
-  if (pid < 0) {
+  if(pid < 0) {
     printf(1, "fork failed\n");
     exit();
   }
 
   unsigned int x = (pid ? 1 : 97);
-  for (i = 0; i < 100; i++) {
+  for(i = 0; i < 100; i++) {
     x = x * 1103515245 + 12345;
-    if ((x % 3) == 0) {
+    if((x % 3) == 0) {
       close(open("x", O_RDWR | O_CREATE));
-    } else if ((x % 3) == 1) {
+    } else if((x % 3) == 1) {
       link("cat", "x");
     } else {
       unlink("x");
     }
   }
 
-  if (pid)
+  if(pid)
     wait();
   else
     exit();
@@ -856,30 +852,30 @@ void bigdir(void) {
   unlink("bd");
 
   fd = open("bd", O_CREATE);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "bigdir create failed\n");
     exit();
   }
   close(fd);
 
-  for (i = 0; i < 500; i++) {
+  for(i = 0; i < 500; i++) {
     name[0] = 'x';
     name[1] = '0' + (i / 64);
     name[2] = '0' + (i % 64);
     name[3] = '\0';
-    if (link("bd", name) != 0) {
+    if(link("bd", name) != 0) {
       printf(1, "bigdir link failed\n");
       exit();
     }
   }
 
   unlink("bd");
-  for (i = 0; i < 500; i++) {
+  for(i = 0; i < 500; i++) {
     name[0] = 'x';
     name[1] = '0' + (i / 64);
     name[2] = '0' + (i % 64);
     name[3] = '\0';
-    if (unlink(name) != 0) {
+    if(unlink(name) != 0) {
       printf(1, "bigdir unlink failed");
       exit();
     }
@@ -894,31 +890,31 @@ void subdir(void) {
   printf(1, "subdir test\n");
 
   unlink("ff");
-  if (mkdir("dd") != 0) {
+  if(mkdir("dd") != 0) {
     printf(1, "subdir mkdir dd failed\n");
     exit();
   }
 
   fd = open("dd/ff", O_CREATE | O_RDWR);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "create dd/ff failed\n");
     exit();
   }
   write(fd, "ff", 2);
   close(fd);
 
-  if (unlink("dd") >= 0) {
+  if(unlink("dd") >= 0) {
     printf(1, "unlink dd (non-empty dir) succeeded!\n");
     exit();
   }
 
-  if (mkdir("/dd/dd") != 0) {
+  if(mkdir("/dd/dd") != 0) {
     printf(1, "subdir mkdir dd/dd failed\n");
     exit();
   }
 
   fd = open("dd/dd/ff", O_CREATE | O_RDWR);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "create dd/dd/ff failed\n");
     exit();
   }
@@ -926,142 +922,142 @@ void subdir(void) {
   close(fd);
 
   fd = open("dd/dd/../ff", 0);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "open dd/dd/../ff failed\n");
     exit();
   }
   cc = read(fd, buf, sizeof(buf));
-  if (cc != 2 || buf[0] != 'f') {
+  if(cc != 2 || buf[0] != 'f') {
     printf(1, "dd/dd/../ff wrong content\n");
     exit();
   }
   close(fd);
 
-  if (link("dd/dd/ff", "dd/dd/ffff") != 0) {
+  if(link("dd/dd/ff", "dd/dd/ffff") != 0) {
     printf(1, "link dd/dd/ff dd/dd/ffff failed\n");
     exit();
   }
 
-  if (unlink("dd/dd/ff") != 0) {
+  if(unlink("dd/dd/ff") != 0) {
     printf(1, "unlink dd/dd/ff failed\n");
     exit();
   }
-  if (open("dd/dd/ff", O_RDONLY) >= 0) {
+  if(open("dd/dd/ff", O_RDONLY) >= 0) {
     printf(1, "open (unlinked) dd/dd/ff succeeded\n");
     exit();
   }
 
-  if (chdir("dd") != 0) {
+  if(chdir("dd") != 0) {
     printf(1, "chdir dd failed\n");
     exit();
   }
-  if (chdir("dd/../../dd") != 0) {
+  if(chdir("dd/../../dd") != 0) {
     printf(1, "chdir dd/../../dd failed\n");
     exit();
   }
-  if (chdir("dd/../../../dd") != 0) {
+  if(chdir("dd/../../../dd") != 0) {
     printf(1, "chdir dd/../../dd failed\n");
     exit();
   }
-  if (chdir("./..") != 0) {
+  if(chdir("./..") != 0) {
     printf(1, "chdir ./.. failed\n");
     exit();
   }
 
   fd = open("dd/dd/ffff", 0);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "open dd/dd/ffff failed\n");
     exit();
   }
-  if (read(fd, buf, sizeof(buf)) != 2) {
+  if(read(fd, buf, sizeof(buf)) != 2) {
     printf(1, "read dd/dd/ffff wrong len\n");
     exit();
   }
   close(fd);
 
-  if (open("dd/dd/ff", O_RDONLY) >= 0) {
+  if(open("dd/dd/ff", O_RDONLY) >= 0) {
     printf(1, "open (unlinked) dd/dd/ff succeeded!\n");
     exit();
   }
 
-  if (open("dd/ff/ff", O_CREATE | O_RDWR) >= 0) {
+  if(open("dd/ff/ff", O_CREATE | O_RDWR) >= 0) {
     printf(1, "create dd/ff/ff succeeded!\n");
     exit();
   }
-  if (open("dd/xx/ff", O_CREATE | O_RDWR) >= 0) {
+  if(open("dd/xx/ff", O_CREATE | O_RDWR) >= 0) {
     printf(1, "create dd/xx/ff succeeded!\n");
     exit();
   }
-  if (open("dd", O_CREATE) >= 0) {
+  if(open("dd", O_CREATE) >= 0) {
     printf(1, "create dd succeeded!\n");
     exit();
   }
-  if (open("dd", O_RDWR) >= 0) {
+  if(open("dd", O_RDWR) >= 0) {
     printf(1, "open dd rdwr succeeded!\n");
     exit();
   }
-  if (open("dd", O_WRONLY) >= 0) {
+  if(open("dd", O_WRONLY) >= 0) {
     printf(1, "open dd wronly succeeded!\n");
     exit();
   }
-  if (link("dd/ff/ff", "dd/dd/xx") == 0) {
+  if(link("dd/ff/ff", "dd/dd/xx") == 0) {
     printf(1, "link dd/ff/ff dd/dd/xx succeeded!\n");
     exit();
   }
-  if (link("dd/xx/ff", "dd/dd/xx") == 0) {
+  if(link("dd/xx/ff", "dd/dd/xx") == 0) {
     printf(1, "link dd/xx/ff dd/dd/xx succeeded!\n");
     exit();
   }
-  if (link("dd/ff", "dd/dd/ffff") == 0) {
+  if(link("dd/ff", "dd/dd/ffff") == 0) {
     printf(1, "link dd/ff dd/dd/ffff succeeded!\n");
     exit();
   }
-  if (mkdir("dd/ff/ff") == 0) {
+  if(mkdir("dd/ff/ff") == 0) {
     printf(1, "mkdir dd/ff/ff succeeded!\n");
     exit();
   }
-  if (mkdir("dd/xx/ff") == 0) {
+  if(mkdir("dd/xx/ff") == 0) {
     printf(1, "mkdir dd/xx/ff succeeded!\n");
     exit();
   }
-  if (mkdir("dd/dd/ffff") == 0) {
+  if(mkdir("dd/dd/ffff") == 0) {
     printf(1, "mkdir dd/dd/ffff succeeded!\n");
     exit();
   }
-  if (unlink("dd/xx/ff") == 0) {
+  if(unlink("dd/xx/ff") == 0) {
     printf(1, "unlink dd/xx/ff succeeded!\n");
     exit();
   }
-  if (unlink("dd/ff/ff") == 0) {
+  if(unlink("dd/ff/ff") == 0) {
     printf(1, "unlink dd/ff/ff succeeded!\n");
     exit();
   }
-  if (chdir("dd/ff") == 0) {
+  if(chdir("dd/ff") == 0) {
     printf(1, "chdir dd/ff succeeded!\n");
     exit();
   }
-  if (chdir("dd/xx") == 0) {
+  if(chdir("dd/xx") == 0) {
     printf(1, "chdir dd/xx succeeded!\n");
     exit();
   }
 
-  if (unlink("dd/dd/ffff") != 0) {
+  if(unlink("dd/dd/ffff") != 0) {
     printf(1, "unlink dd/dd/ff failed\n");
     exit();
   }
-  if (unlink("dd/ff") != 0) {
+  if(unlink("dd/ff") != 0) {
     printf(1, "unlink dd/ff failed\n");
     exit();
   }
-  if (unlink("dd") == 0) {
+  if(unlink("dd") == 0) {
     printf(1, "unlink non-empty dd succeeded!\n");
     exit();
   }
-  if (unlink("dd/dd") < 0) {
+  if(unlink("dd/dd") < 0) {
     printf(1, "unlink dd/dd failed\n");
     exit();
   }
-  if (unlink("dd") < 0) {
+  if(unlink("dd") < 0) {
     printf(1, "unlink dd failed\n");
     exit();
   }
@@ -1076,16 +1072,16 @@ void bigwrite(void) {
   printf(1, "bigwrite test\n");
 
   unlink("bigwrite");
-  for (sz = 499; sz < 12 * 512; sz += 471) {
+  for(sz = 499; sz < 12 * 512; sz += 471) {
     fd = open("bigwrite", O_CREATE | O_RDWR);
-    if (fd < 0) {
+    if(fd < 0) {
       printf(1, "cannot create bigwrite\n");
       exit();
     }
     int i;
-    for (i = 0; i < 2; i++) {
+    for(i = 0; i < 2; i++) {
       int cc = write(fd, buf, sz);
-      if (cc != sz) {
+      if(cc != sz) {
         printf(1, "write(%d) ret %d\n", sz, cc);
         exit();
       }
@@ -1104,13 +1100,13 @@ void bigfile(void) {
 
   unlink("bigfile");
   fd = open("bigfile", O_CREATE | O_RDWR);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "cannot create bigfile");
     exit();
   }
-  for (i = 0; i < 20; i++) {
+  for(i = 0; i < 20; i++) {
     memset(buf, i, 600);
-    if (write(fd, buf, 600) != 600) {
+    if(write(fd, buf, 600) != 600) {
       printf(1, "write bigfile failed\n");
       exit();
     }
@@ -1118,31 +1114,31 @@ void bigfile(void) {
   close(fd);
 
   fd = open("bigfile", 0);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "cannot open bigfile\n");
     exit();
   }
   total = 0;
-  for (i = 0;; i++) {
+  for(i = 0;; i++) {
     cc = read(fd, buf, 300);
-    if (cc < 0) {
+    if(cc < 0) {
       printf(1, "read bigfile failed\n");
       exit();
     }
-    if (cc == 0)
+    if(cc == 0)
       break;
-    if (cc != 300) {
+    if(cc != 300) {
       printf(1, "short read bigfile\n");
       exit();
     }
-    if (buf[0] != i / 2 || buf[299] != i / 2) {
+    if(buf[0] != i / 2 || buf[299] != i / 2) {
       printf(1, "read bigfile wrong data\n");
       exit();
     }
     total += cc;
   }
   close(fd);
-  if (total != 20 * 600) {
+  if(total != 20 * 600) {
     printf(1, "read bigfile wrong total\n");
     exit();
   }
@@ -1157,33 +1153,33 @@ void fourteen(void) {
   // DIRSIZ is 14.
   printf(1, "fourteen test\n");
 
-  if (mkdir("12345678901234") != 0) {
+  if(mkdir("12345678901234") != 0) {
     printf(1, "mkdir 12345678901234 failed\n");
     exit();
   }
-  if (mkdir("12345678901234/123456789012345") != 0) {
+  if(mkdir("12345678901234/123456789012345") != 0) {
     printf(1, "mkdir 12345678901234/123456789012345 failed\n");
     exit();
   }
   fd = open("123456789012345/123456789012345/123456789012345", O_CREATE);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1,
-           "create 123456789012345/123456789012345/123456789012345 failed\n");
+        "create 123456789012345/123456789012345/123456789012345 failed\n");
     exit();
   }
   close(fd);
   fd = open("12345678901234/12345678901234/12345678901234", 0);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "open 12345678901234/12345678901234/12345678901234 failed\n");
     exit();
   }
   close(fd);
 
-  if (mkdir("12345678901234/12345678901234") == 0) {
+  if(mkdir("12345678901234/12345678901234") == 0) {
     printf(1, "mkdir 12345678901234/12345678901234 succeeded!\n");
     exit();
   }
-  if (mkdir("123456789012345/12345678901234") == 0) {
+  if(mkdir("123456789012345/12345678901234") == 0) {
     printf(1, "mkdir 12345678901234/123456789012345 succeeded!\n");
     exit();
   }
@@ -1193,35 +1189,35 @@ void fourteen(void) {
 
 void rmdot(void) {
   printf(1, "rmdot test\n");
-  if (mkdir("dots") != 0) {
+  if(mkdir("dots") != 0) {
     printf(1, "mkdir dots failed\n");
     exit();
   }
-  if (chdir("dots") != 0) {
+  if(chdir("dots") != 0) {
     printf(1, "chdir dots failed\n");
     exit();
   }
-  if (unlink(".") == 0) {
+  if(unlink(".") == 0) {
     printf(1, "rm . worked!\n");
     exit();
   }
-  if (unlink("..") == 0) {
+  if(unlink("..") == 0) {
     printf(1, "rm .. worked!\n");
     exit();
   }
-  if (chdir("/") != 0) {
+  if(chdir("/") != 0) {
     printf(1, "chdir / failed\n");
     exit();
   }
-  if (unlink("dots/.") == 0) {
+  if(unlink("dots/.") == 0) {
     printf(1, "unlink dots/. worked!\n");
     exit();
   }
-  if (unlink("dots/..") == 0) {
+  if(unlink("dots/..") == 0) {
     printf(1, "unlink dots/.. worked!\n");
     exit();
   }
-  if (unlink("dots") != 0) {
+  if(unlink("dots") != 0) {
     printf(1, "unlink dots failed!\n");
     exit();
   }
@@ -1234,49 +1230,49 @@ void dirfile(void) {
   printf(1, "dir vs file\n");
 
   fd = open("dirfile", O_CREATE);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(1, "create dirfile failed\n");
     exit();
   }
   close(fd);
-  if (chdir("dirfile") == 0) {
+  if(chdir("dirfile") == 0) {
     printf(1, "chdir dirfile succeeded!\n");
     exit();
   }
   fd = open("dirfile/xx", 0);
-  if (fd >= 0) {
+  if(fd >= 0) {
     printf(1, "create dirfile/xx succeeded!\n");
     exit();
   }
   fd = open("dirfile/xx", O_CREATE);
-  if (fd >= 0) {
+  if(fd >= 0) {
     printf(1, "create dirfile/xx succeeded!\n");
     exit();
   }
-  if (mkdir("dirfile/xx") == 0) {
+  if(mkdir("dirfile/xx") == 0) {
     printf(1, "mkdir dirfile/xx succeeded!\n");
     exit();
   }
-  if (unlink("dirfile/xx") == 0) {
+  if(unlink("dirfile/xx") == 0) {
     printf(1, "unlink dirfile/xx succeeded!\n");
     exit();
   }
-  if (link("README", "dirfile/xx") == 0) {
+  if(link("README", "dirfile/xx") == 0) {
     printf(1, "link to dirfile/xx succeeded!\n");
     exit();
   }
-  if (unlink("dirfile") != 0) {
+  if(unlink("dirfile") != 0) {
     printf(1, "unlink dirfile failed!\n");
     exit();
   }
 
   fd = open(".", O_RDWR);
-  if (fd >= 0) {
+  if(fd >= 0) {
     printf(1, "open . for writing succeeded!\n");
     exit();
   }
   fd = open(".", 0);
-  if (write(fd, "x", 1) > 0) {
+  if(write(fd, "x", 1) > 0) {
     printf(1, "write . succeeded!\n");
     exit();
   }
@@ -1292,12 +1288,12 @@ void iref(void) {
   printf(1, "empty file name\n");
 
   // the 50 is NINODE
-  for (i = 0; i < 50 + 1; i++) {
-    if (mkdir("irefd") != 0) {
+  for(i = 0; i < 50 + 1; i++) {
+    if(mkdir("irefd") != 0) {
       printf(1, "mkdir irefd failed\n");
       exit();
     }
-    if (chdir("irefd") != 0) {
+    if(chdir("irefd") != 0) {
       printf(1, "chdir irefd failed\n");
       exit();
     }
@@ -1305,10 +1301,10 @@ void iref(void) {
     mkdir("");
     link("README", "");
     fd = open("", O_CREATE);
-    if (fd >= 0)
+    if(fd >= 0)
       close(fd);
     fd = open("xx", O_CREATE);
-    if (fd >= 0)
+    if(fd >= 0)
       close(fd);
     unlink("xx");
   }
@@ -1325,27 +1321,27 @@ void forktest(void) {
 
   printf(1, "fork test\n");
 
-  for (n = 0; n < 1000; n++) {
+  for(n = 0; n < 1000; n++) {
     pid = fork();
-    if (pid < 0)
+    if(pid < 0)
       break;
-    if (pid == 0)
+    if(pid == 0)
       exit();
   }
 
-  if (n == 1000) {
+  if(n == 1000) {
     printf(1, "fork claimed to work 1000 times!\n");
     exit();
   }
 
-  for (; n > 0; n--) {
-    if (wait() < 0) {
+  for(; n > 0; n--) {
+    if(wait() < 0) {
       printf(1, "wait stopped early\n");
       exit();
     }
   }
 
-  if (wait() != -1) {
+  if(wait() != -1) {
     printf(1, "wait got too many\n");
     exit();
   }
@@ -1364,9 +1360,9 @@ void sbrktest(void) {
   // can one sbrk() less than a page?
   a = sbrk(0);
   int i;
-  for (i = 0; i < 5000; i++) {
+  for(i = 0; i < 5000; i++) {
     b = sbrk(1);
-    if (b != a) {
+    if(b != a) {
       printf(stdout, "sbrk test failed %d %x %x\n", i, a, b);
       exit();
     }
@@ -1374,31 +1370,31 @@ void sbrktest(void) {
     a = b + 1;
   }
   pid = fork();
-  if (pid < 0) {
+  if(pid < 0) {
     printf(stdout, "sbrk test fork failed\n");
     exit();
   }
   c = sbrk(1);
   c = sbrk(1);
-  if (c != a + 1) {
+  if(c != a + 1) {
     printf(stdout, "sbrk test failed post-fork\n");
     exit();
   }
-  if (pid == 0)
+  if(pid == 0)
     exit();
   wait();
 
   // can one grow address space to something big?
 #define BIG (100 * 1024 * 1024)
   a = sbrk(0);
-  amt = (BIG) - (uint)a;
+  amt = (BIG) - (uint) a;
   p = sbrk(amt);
-  if (p != a) {
+  if(p != a) {
     printf(stdout,
-           "sbrk test failed to grow big address space; enough phys mem?\n");
+        "sbrk test failed to grow big address space; enough phys mem?\n");
     exit();
   }
-  lastaddr = (char *)(BIG - 1);
+  lastaddr = (char*) (BIG - 1);
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
   *lastaddr = 99;
 #pragma GCC diagnostic pop
@@ -1406,25 +1402,25 @@ void sbrktest(void) {
   // can one de-allocate?
   a = sbrk(0);
   c = sbrk(-4096);
-  if (c == (char *)0xffffffff) {
+  if(c == (char*) 0xffffffff) {
     printf(stdout, "sbrk could not deallocate\n");
     exit();
   }
   c = sbrk(0);
-  if (c != a - 4096) {
+  if(c != a - 4096) {
     printf(stdout, "sbrk deallocation produced wrong address, a %x c %x\n", a,
-           c);
+        c);
     exit();
   }
 
   // can one re-allocate that page?
   a = sbrk(0);
   c = sbrk(4096);
-  if (c != a || sbrk(0) != a + 4096) {
+  if(c != a || sbrk(0) != a + 4096) {
     printf(stdout, "sbrk re-allocation failed, a %x c %x\n", a, c);
     exit();
   }
-  if (*lastaddr == 99) {
+  if(*lastaddr == 99) {
     // should be zero
     printf(stdout, "sbrk de-allocation didn't really deallocate\n");
     exit();
@@ -1432,20 +1428,20 @@ void sbrktest(void) {
 
   a = sbrk(0);
   c = sbrk(-(sbrk(0) - oldbrk));
-  if (c != a) {
+  if(c != a) {
     printf(stdout, "sbrk downsize failed, a %x c %x\n", a, c);
     exit();
   }
 
   // can we read the kernel's memory?
-  for (a = (char *)(KERNBASE); a < (char *)(KERNBASE + 2000000); a += 50000) {
+  for(a = (char*) (KERNBASE); a < (char*) (KERNBASE + 2000000); a += 50000) {
     ppid = getpid();
     pid = fork();
-    if (pid < 0) {
+    if(pid < 0) {
       printf(stdout, "fork failed\n");
       exit();
     }
-    if (pid == 0) {
+    if(pid == 0) {
       printf(stdout, "oops could read %x = %x\n", a, *a);
       kill(ppid);
       exit();
@@ -1455,43 +1451,43 @@ void sbrktest(void) {
 
   // if we run the system out of memory, does it clean up the last
   // failed allocation?
-  if (pipe(fds) != 0) {
+  if(pipe(fds) != 0) {
     printf(1, "pipe() failed\n");
     exit();
   }
-  for (i = 0; i < sizeof(pids) / sizeof(pids[0]); i++) {
-    if ((pids[i] = fork()) == 0) {
+  for(i = 0; i < sizeof(pids) / sizeof(pids[0]); i++) {
+    if((pids[i] = fork()) == 0) {
       // allocate a lot of memory
-      sbrk(BIG - (uint)sbrk(0));
+      sbrk(BIG - (uint) sbrk(0));
       write(fds[1], "x", 1);
       // sit around until killed
-      for (;;)
+      for(;;)
         sleep(1000);
     }
-    if (pids[i] != -1)
+    if(pids[i] != -1)
       read(fds[0], &scratch, 1);
   }
   // if those failed allocations freed up the pages they did allocate,
   // we'll be able to allocate here
   c = sbrk(4096);
-  for (i = 0; i < sizeof(pids) / sizeof(pids[0]); i++) {
-    if (pids[i] == -1)
+  for(i = 0; i < sizeof(pids) / sizeof(pids[0]); i++) {
+    if(pids[i] == -1)
       continue;
     kill(pids[i]);
     wait();
   }
-  if (c == (char *)0xffffffff) {
+  if(c == (char*) 0xffffffff) {
     printf(stdout, "failed sbrk leaked memory\n");
     exit();
   }
 
-  if (sbrk(0) > oldbrk)
+  if(sbrk(0) > oldbrk)
     sbrk(-(sbrk(0) - oldbrk));
 
   printf(stdout, "sbrk test OK\n");
 }
 
-void validateint(int *p) {
+void validateint(int* p) {
   int res;
   asm("mov %%esp, %%ebx\n\t"
       "mov %3, %%esp\n\t"
@@ -1509,10 +1505,10 @@ void validatetest(void) {
   printf(stdout, "validate test\n");
   hi = 1100 * 1024;
 
-  for (p = 0; p <= (uint)hi; p += 4096) {
-    if ((pid = fork()) == 0) {
+  for(p = 0; p <= (uint) hi; p += 4096) {
+    if((pid = fork()) == 0) {
       // try to crash the kernel by passing in a badly placed integer
-      validateint((int *)p);
+      validateint((int*) p);
       exit();
     }
     sleep(0);
@@ -1521,7 +1517,7 @@ void validatetest(void) {
     wait();
 
     // try to crash the kernel by passing in a bad string pointer
-    if (link("nosuchfile", (char *)p) != -1) {
+    if(link("nosuchfile", (char*) p) != -1) {
       printf(stdout, "link should not succeed\n");
       exit();
     }
@@ -1536,8 +1532,8 @@ void bsstest(void) {
   int i;
 
   printf(stdout, "bss test\n");
-  for (i = 0; i < sizeof(uninit); i++) {
-    if (uninit[i] != '\0') {
+  for(i = 0; i < sizeof(uninit); i++) {
+    if(uninit[i] != '\0') {
       printf(stdout, "bss test failed\n");
       exit();
     }
@@ -1553,14 +1549,15 @@ void bigargtest(void) {
 
   unlink("bigarg-ok");
   pid = fork();
-  if (pid == 0) {
-    static char *args[MAXARG];
+  if(pid == 0) {
+    static char* args[MAXARG];
     int i;
-    for (i = 0; i < MAXARG - 1; i++)
-      args[i] = "bigargs test: failed\n                                        "
-                "                                                              "
-                "                                                              "
-                "                                   ";
+    for(i = 0; i < MAXARG - 1; i++)
+      args[i] =
+          "bigargs test: failed\n                                        "
+          "                                                              "
+          "                                                              "
+          "                                   ";
     args[MAXARG - 1] = 0;
     printf(stdout, "bigarg test\n");
     exec("echo", args);
@@ -1568,13 +1565,13 @@ void bigargtest(void) {
     fd = open("bigarg-ok", O_CREATE);
     close(fd);
     exit();
-  } else if (pid < 0) {
+  } else if(pid < 0) {
     printf(stdout, "bigargtest: fork failed\n");
     exit();
   }
   wait();
   fd = open("bigarg-ok", 0);
-  if (fd < 0) {
+  if(fd < 0) {
     printf(stdout, "bigarg test failed!\n");
     exit();
   }
@@ -1590,7 +1587,7 @@ void fsfull() {
 
   printf(1, "fsfull test\n");
 
-  for (nfiles = 0;; nfiles++) {
+  for(nfiles = 0;; nfiles++) {
     char name[64];
     name[0] = 'f';
     name[1] = '0' + nfiles / 1000;
@@ -1600,25 +1597,25 @@ void fsfull() {
     name[5] = '\0';
     printf(1, "writing %s\n", name);
     int fd = open(name, O_CREATE | O_RDWR);
-    if (fd < 0) {
+    if(fd < 0) {
       printf(1, "open %s failed\n", name);
       break;
     }
     int total = 0;
-    while (1) {
+    while(1) {
       int cc = write(fd, buf, 512);
-      if (cc < 512)
+      if(cc < 512)
         break;
       total += cc;
       fsblocks++;
     }
     printf(1, "wrote %d bytes\n", total);
     close(fd);
-    if (total == 0)
+    if(total == 0)
       break;
   }
 
-  while (nfiles >= 0) {
+  while(nfiles >= 0) {
     char name[64];
     name[0] = 'f';
     name[1] = '0' + nfiles / 1000;
@@ -1639,10 +1636,10 @@ unsigned int rand() {
   return randstate;
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   printf(1, "usertests starting\n");
 
-  if (open("usertests.ran", 0) >= 0) {
+  if(open("usertests.ran", 0) >= 0) {
     printf(1, "already ran user tests -- rebuild fs.img\n");
     exit();
   }

--- a/user/wc.c
+++ b/user/wc.c
@@ -1,45 +1,43 @@
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
 
 char buf[512];
 
-void wc(int fd, char *name) {
+void wc(int fd, char* name) {
   int i, n;
   int l, w, c, inword;
 
   l = w = c = 0;
   inword = 0;
-  while ((n = read(fd, buf, sizeof(buf))) > 0) {
-    for (i = 0; i < n; i++) {
+  while((n = read(fd, buf, sizeof(buf))) > 0) {
+    for(i = 0; i < n; i++) {
       c++;
-      if (buf[i] == '\n')
+      if(buf[i] == '\n')
         l++;
-      if (strchr(" \r\t\n\v", buf[i]))
+      if(strchr(" \r\t\n\v", buf[i]))
         inword = 0;
-      else if (!inword) {
+      else if(!inword) {
         w++;
         inword = 1;
       }
     }
   }
-  if (n < 0) {
+  if(n < 0) {
     printf(1, "wc: read error\n");
     exit();
   }
   printf(1, "%d %d %d %s\n", l, w, c, name);
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   int fd, i;
 
-  if (argc <= 1) {
+  if(argc <= 1) {
     wc(0, "");
     exit();
   }
 
-  for (i = 1; i < argc; i++) {
-    if ((fd = open(argv[i], 0)) < 0) {
+  for(i = 1; i < argc; i++) {
+    if((fd = open(argv[i], 0)) < 0) {
       printf(1, "wc: cannot open %s\n", argv[i]);
       exit();
     }

--- a/user/zombie.c
+++ b/user/zombie.c
@@ -1,12 +1,9 @@
 // Create a zombie process that
 // must be reparented at exit.
-
-#include "kernel/types.h"
-#include "kernel/stat.h"
 #include "user.h"
 
 int main(void) {
-  if (fork() > 0)
+  if(fork() > 0)
     sleep(5); // Let child exit before parent.
   exit();
 }


### PR DESCRIPTION
xv6 used to be the modern incarnation of the original SysV Unix source code, and had some oddities associated with it in that vein. The source code used to also be used to generate a textbook-like structure. Neither the K&R style nor the textbook generation has been respected in the NYU fork.

This patch is the first step in moving away from that structure, as it doesn't have pedagogical value to students. It also removes things we never use from the build process, such as the objdumps that were generated.

The broad reformatting is included here so that the changes in future patches aren't drowned out in the noise of this one.

* Reformat remaining K&R formatting
* Remove all references to pagebreaks
* Remove all kernel includes from userspace programs
* Remove objdumps from build process

Future work:
* Refactoring functions away from C89-style
* Removing perl scripts
* Rewriting the (abandoned? lost?) vector table generator
* Replacing inline-assembly with compiler intrinsics
* Rewriting remaining assembly in Intel syntax (all other undergrad courses use Intel)

Long Term:
* Ditch `make`

I'm going to let this float here for a bit because I need feedback from the grad OS people. This is the direction the undergrad course is going to go, but if the changes are acceptable to the grad version of the course it would be nice to have a single repo.